### PR TITLE
docs: HANDOFF/backlog の crate 数を 4→5 に修正 (auth-server 追加)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,13 +5,14 @@
 
 ## 現状
 
-### Workspace: 4 crates, テスト: auth-core 55 (46 unit + 9 integration), gateway 8 integration
+### Workspace: 5 crates, テスト: auth-core 55 (46 unit + 9 integration), gateway 8 integration
 
 ```
 volta-gateway/
   Cargo.toml              workspace root
   gateway/                HTTP reverse proxy (30+ features)
   auth-core/              Auth library (5 tramli SM flows)
+  auth-server/            Auth HTTP API server
   volta-bin/              Unified binary (gateway + auth in-process)
   tools/traefik-to-volta/ Config converter CLI
 ```

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -23,7 +23,7 @@
 - Benchmark 記事, Getting Started, README 更新
 
 **Tests: 63** (auth-core 55 + gateway 8)
-**Crates: 4** (gateway, auth-core, volta-bin, traefik-to-volta)
+**Crates: 5** (gateway, auth-core, auth-server, volta-bin, traefik-to-volta)
 </details>
 
 ---


### PR DESCRIPTION
Closes #100

## 問題
`docs/HANDOFF.md:8` と `docs/backlog.md:26` が `4 crates` と古い記載のまま、`auth-server` crate の追加（v0.2.0 で言及）が反映されていなかった。実測は `Cargo.toml` members = 5 crates。

## 修正内容（issue #100 選択肢 a 採用）
- `docs/HANDOFF.md:8`: "4 crates" → "5 crates"、crates 一覧に `auth-server/` 行を追加
- `docs/backlog.md:26`: "Crates: 4" → "Crates: 5"、一覧に `auth-server` を追加

## 検証
- `rg 'crates|Crates' docs/HANDOFF.md docs/backlog.md` → 両ファイルとも "5" に更新済み
- `Cargo.toml` members（5 crate）と一致
- ドキュメントのみの変更、ビルド影響なし、回帰テスト不要

## 範囲外（別 issue で扱う）
- テスト数の陳腐化 → #99
- ルート数の自己矛盾 → #98
- SPEC 固定値全体の陳腐化 → #82