### PR TITLE
fix(gateway,auth-server): 起動時の unwrap を診断性のある exit(1) に置換 (#97)

### DIFF
--- a/auth-server/src/main.rs
+++ b/auth-server/src/main.rs
@@ -35,10 +35,18 @@ async fn main() {
         .init();
 
     // Config from env vars (Java compat: same env var names)
-    let port: u16 = env("PORT", "7070").parse().unwrap();
+    let port: u16 = env("PORT", "7070").parse().unwrap_or_else(|e| {
+        eprintln!("PORT: invalid integer ({e})");
+        std::process::exit(1);
+    });
     let database_url = env("DATABASE_URL", "postgres://localhost/volta");
     let jwt_secret = env("JWT_SECRET", "volta-dev-secret-change-me-in-prod");
-    let session_ttl: u64 = env("SESSION_TTL_SECONDS", "28800").parse().unwrap();
+    let session_ttl: u64 = env("SESSION_TTL_SECONDS", "28800")
+        .parse()
+        .unwrap_or_else(|e| {
+            eprintln!("SESSION_TTL_SECONDS: invalid integer ({e})");
+            std::process::exit(1);
+        });
     let cookie_domain = env("COOKIE_DOMAIN", "");
     let force_secure = env("FORCE_SECURE_COOKIE", "false") == "true";
     let base_url = env("BASE_URL", &format!("http://localhost:{}", port));
@@ -177,7 +185,12 @@ async fn main() {
 
     info!(port = port, "volta-auth-server starting");
 
-    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .unwrap_or_else(|e| {
+            eprintln!("failed to bind {addr}: {e} (port already in use?)");
+            std::process::exit(1);
+        });
     // `into_make_service_with_connect_info` makes peer SocketAddr available to
     // handlers/middleware via `ConnectInfo<SocketAddr>` — needed for the IP-keyed
     // rate limiter (#7, #10).

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -136,7 +136,10 @@ async fn main() {
 
     info!(port = config.server.port, "volta-gateway starting");
 
-    let listener = TcpListener::bind(addr).await.unwrap();
+    let listener = TcpListener::bind(addr).await.unwrap_or_else(|e| {
+        error!("failed to bind {addr}: {e} (port already in use?)");
+        std::process::exit(1);
+    });
     info!(addr = %addr, "listening");
 
     // Shared snapshot of config-source (services.json/docker/http) routes so a


### PR DESCRIPTION
## 対象 issue

Closes #97

## 変更概要

`gateway/src/main.rs` と `auth-server/src/main.rs` の起動パスにあった `unwrap()` を、原因が1行で分かるメッセージ付きの `unwrap_or_else(|e| { eprintln!/error!; exit(1) })` に置換した。panic+スタックトレースではなく、メッセージを出して `exit(1)` する。

issue #97 の推奨 (a)（`expect()` 化）をさらに一歩進め、同ファイル内の既存パターン（`PgPool::connect` の `.unwrap_or_else(|e| { eprintln!(...); exit(1) })`）に揃えた。これにより panic が完全に消え、エラー種別（ポート競合 / env 不正）ごとにメッセージが分かる。

## 対象箇所

- `gateway/src/main.rs:139` — `TcpListener::bind(addr).await.unwrap()`
- `auth-server/src/main.rs:38` — `env("PORT", ...).parse().unwrap()`
- `auth-server/src/main.rs:41` — `env("SESSION_TTL_SECONDS", ...).parse().unwrap()`
- `auth-server/src/main.rs:180` — `TcpListener::bind(addr).await.unwrap()`

## 挙動互換性

- 変更前: panic + スタックトレース（終了コード 101）
- 変更後: `eprintln!` / `error!` 1行 + `exit(1)`（終了コード 1）
- どちらも非0終了。本番運用でプロセスが落ちる挙動は同じ。診断性のみ向上。
- 破壊的変更なし。仕様変更なし。

## 実施内容（LOOP ENGINEERING 反復1）

- **loop 分類**: bug → `issue-fix` loop（ラベルなし、本文 `[audit][robustness]` より）
- **再現確認**: 指摘4箇所すべて main ブランチで確認
- **修正**: worktree (`/tmp/opencode/issue-97-unwrap`) で隔離作業
- **検証**:
  - `cargo build -p volta-gateway -p volta-auth-server` → 成功
  - `cargo test -p volta-gateway --bin volta-gateway` → 84 passed
  - `cargo test -p volta-auth-server --bin volta-auth-server` → 91 passed
  - `cargo clippy` → 変更箇所に新規警告なし（21 warnings は全て既存コード）
  - 変更箇所は rustfmt 整形式（main ブランド自体が fmt 不整備だが私の変更箇所はクリーン）

## 人間ゲート

該当なし。仕様変更・破壊的変更・広いリファクタいずれもなし。issue #97 が提示した選択肢 (a)(b)(c) のうち (a) を採用。(b) は issue が「別 issue が望ましい」と明記、(c) は backlog 行きで対応しない。

## 外部情報

使用していない。すべてローカルファイル観測。

## LOOP_ROUTE

LOOP_ROUTE: issue-fix