### PR TITLE
docs(spec): §3.1 migration 表を 024-033 追加 (#89) + 008/009/022/023 説明欄修正 (#90)

### DIFF
--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -116,7 +116,7 @@ volta-gateway/                          Cargo workspace root
 │   │   ├── passkey.rs        — webauthn-rs adapter
 │   │   ├── policy.rs         — RBAC engine
 │   │   └── crypto.rs         — KeyCipher (AES-GCM + PBKDF2)
-│   ├── migrations/           — 23 SQL files (001 → 023)
+│   ├── migrations/           — 33 SQL files (001 → 033)
 │   └── tests/                — pg_store_test (testcontainers)
 ├── auth-server/                        Axum HTTP API crate (96 routes)
 │   ├── src/
@@ -347,10 +347,10 @@ off-by-one bug documented as Java issue #20.
 
 ## 3. Data Persistence Layer
 
-### 3.1 Migrations (23 files)
+### 3.1 Migrations (33 files)
 
 All migrations live in `auth-core/migrations/` and are numbered `NNN_*.sql`.
-They are applied in order; the current head is **023**. Each migration is
+They are applied in order; the current head is **033**. Each migration is
 idempotent via `CREATE … IF NOT EXISTS` / `CREATE UNIQUE INDEX IF NOT EXISTS`.
 
 | #   | File                                | Purpose                                                  |
@@ -378,6 +378,16 @@ idempotent via `CREATE … IF NOT EXISTS` / `CREATE UNIQUE INDEX IF NOT EXISTS`.
 | 021 | `021_pagination_indexes.sql`        | Composite indexes for admin pagination (P2.1, Java `f31a2f2`) on `audit_logs`, `sessions`, `users`, `invitations`, `members` |
 | 022 | `022_create_oidc_flows.sql`         | `oidc_flows` — state (HMAC-signed), nonce, pkce_verifier (KeyCipher), expires_at. Atomic consume per Java #3. |
 | 023 | `023_create_passkey_challenges.sql` | `passkey_challenges` — user_id, challenge (serialised via `bincode`), expires_at |
+| 024 | `024_create_notification_jobs.sql` | `notification_jobs` — channel, recipient, template_id, payload (template vars only, no tokens), correlation_id (UNIQUE — idempotency), status, attempt_count, next_attempt_at; `notification_logs` — delivery audit |
+| 025 | `025_create_email_verification_tokens.sql` | `email_verification_tokens` — email, token_hash (SHA-256, plain token never stored), flow_id (optional link), expires_at, used_at (one-time), attempt_count, resend_count, last_sent_at (rate-limit attributes) |
+| 026 | `026_create_login_challenges.sql` | `login_challenges` — user_id, kind (EMAIL_OTP / SMS_OTP / LINE_OTP), code_hash (SHA-256), destination, expires_at, consumed_at (one-time), attempt_count, max_attempts |
+| 027 | `027_user_mfa_unique_index.sql` | `UNIQUE INDEX user_mfa_user_type_uniq (user_id, type)` — required for `MfaStore` upsert `ON CONFLICT (user_id, type)` (parity with Java V7; was missing in Rust schema, upsert failed on fresh DB) |
+| 028 | `028_create_device_authorization_grants.sql` | `device_authorization_grants` — device_code_hash (SHA-256, plain device_code never stored), user_code (human code, UNIQUE), client_id, scope, status (pending/approved/denied/expired), user_id/tenant_id (set on approval), interval_secs (slow_down), last_polled_at, expires_at (RFC 8628) |
+| 029 | `029_create_oauth_provider.sql` | `oauth_clients` — client_id (UNIQUE), client_secret_hash (NULL = public/PKCE), redirect_uris[], grant_types[], scopes[], is_confidential; `oauth_authorization_codes` — code_hash (SHA-256 PK), client_id, user_id, tenant_id, redirect_uri, scope, nonce, code_challenge, code_challenge_method, expires_at, consumed_at; `oauth_refresh_tokens` — rotating refresh tokens with reuse detection via family_id; `oauth_consents` — remembered consent |
+| 030 | `030_create_risk_known_devices.sql` | `risk_known_devices` — (user_id, device_hash SHA-256 of `__volta_kd` cookie) PK, first_seen, last_seen. Invisible to user, feeds risk scoring only; distinct from user-managed trusted_devices (018) |
+| 031 | `031_oauth_client_logout_uris.sql` | `ALTER TABLE oauth_clients` ADD `backchannel_logout_uri` / `frontchannel_logout_uri` (OIDC RP-initiated / back-channel / front-channel logout endpoints) |
+| 032 | `032_create_user_identities.sql` | `user_identities` — user_id, provider, subject (UNIQUE (provider, subject) — IdP stable sub), email, email_verified, created_at. Account linking: one user owns several federated identities; verified-email match links to existing user instead of creating a duplicate |
+| 033 | `033_create_session_stepup.sql` | `session_stepup` — session_id PK, created_at. Risk step-up marker set by adaptive auth; ForwardAuth routes marked sessions through `/mfa/challenge` even when tenant policy wouldn't normally require MFA. Per-session so a fresh passkey re-auth (new, unmarked session) satisfies it |
 
 **Extension set:** migrations assume PostgreSQL 13+ with `pgcrypto` and
 `uuid-ossp` (or equivalent server-side UUID). `ON DELETE CASCADE` is used for

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -362,8 +362,8 @@ idempotent via `CREATE … IF NOT EXISTS` / `CREATE UNIQUE INDEX IF NOT EXISTS`.
 | 005 | `005_create_invitation_usages.sql`  | `invitation_usages` — audit of single-use acceptance (idempotent accept) |
 | 006 | `006_create_auth_flows.sql`         | `auth_flows` — tramli FlowInstance persistence (flow_id, flow_name, current_state, data_json, version, ttl_expires_at). Optimistic lock via `version`. |
 | 007 | `007_create_auth_flow_transitions.sql` | `auth_flow_transitions` — append-only transition log (from_state, to_state, duration_micros, data_types, timestamp). Feeds `/api/v1/admin/flows/{id}/transitions`. |
-| 008 | `008_create_sessions.sql`           | `sessions` — id (JWT session_id claim), user_id, tenant_id, created_at, revoked_at, last_used_at, ip, user_agent, mfa_verified_at |
-| 009 | `009_create_user_mfa.sql`           | `user_mfa` — user_id PK, totp_secret (KeyCipher-encrypted), enabled_at |
+| 008 | `008_create_sessions.sql`           | `sessions` — id (VARCHAR PK, JWT session_id claim), user_id, tenant_id, return_to, created_at (BIGINT), last_active_at (BIGINT), expires_at (BIGINT), invalidated_at (BIGINT, replaces revoked_at), mfa_verified_at (BIGINT), ip_address, user_agent, csrf_token, email, tenant_slug, roles, display_name |
+| 009 | `009_create_user_mfa.sql`           | `user_mfa` — id (UUID PK), user_id (FK → users), type (VARCHAR(20), e.g. totp/passkey), secret (TEXT), is_active (BOOLEAN), created_at. UNIQUE INDEX (user_id, type) added by migration 027 for `ON CONFLICT` upsert |
 | 010 | `010_create_mfa_recovery_codes.sql` | `mfa_recovery_codes` — user_id, code_hash (SHA-256), used_at |
 | 011 | `011_create_magic_links.sql`        | `magic_links` — token_hash, email, expires_at, consumed_at |
 | 012 | `012_create_signing_keys.sql`       | `signing_keys` — kid, alg, public_jwk, private_jwk (KeyCipher), not_before, not_after, revoked_at |
@@ -376,8 +376,8 @@ idempotent via `CREATE … IF NOT EXISTS` / `CREATE UNIQUE INDEX IF NOT EXISTS`.
 | 019 | `019_create_billing.sql`            | `plans`, `subscriptions` (Stripe-compatible), `invoices` |
 | 020 | `020_create_policies.sql`           | `tenant_security_policies` — policy_json (RBAC / time-of-day / geo) |
 | 021 | `021_pagination_indexes.sql`        | Composite indexes for admin pagination (P2.1, Java `f31a2f2`) on `audit_logs`, `sessions`, `users`, `invitations`, `members` |
-| 022 | `022_create_oidc_flows.sql`         | `oidc_flows` — state (HMAC-signed), nonce, pkce_verifier (KeyCipher), expires_at. Atomic consume per Java #3. |
-| 023 | `023_create_passkey_challenges.sql` | `passkey_challenges` — user_id, challenge (serialised via `bincode`), expires_at |
+| 022 | `022_create_oidc_flows.sql`         | `oidc_flows` — id (UUID PK), state (VARCHAR UNIQUE — DB-backed opaque value, replaces prior HMAC-signed stateless state), nonce, code_verifier_encrypted (KeyCipher AES-GCM), return_to, invite_code, tenant_id, created_at, expires_at. Atomic single-use consume per Java #3. |
+| 023 | `023_create_passkey_challenges.sql` | `passkey_challenges` — id (UUID PK), user_id (NULL for login — user not yet resolved), state (BYTEA — serde_json-serialised `PasskeyAuthentication`/`PasskeyRegistration`, moved from bincode per CHANGELOG [Unreleased]), kind ("auth" / "register"), created_at, expires_at |
 | 024 | `024_create_notification_jobs.sql` | `notification_jobs` — channel, recipient, template_id, payload (template vars only, no tokens), correlation_id (UNIQUE — idempotency), status, attempt_count, next_attempt_at; `notification_logs` — delivery audit |
 | 025 | `025_create_email_verification_tokens.sql` | `email_verification_tokens` — email, token_hash (SHA-256, plain token never stored), flow_id (optional link), expires_at, used_at (one-time), attempt_count, resend_count, last_sent_at (rate-limit attributes) |
 | 026 | `026_create_login_challenges.sql` | `login_challenges` — user_id, kind (EMAIL_OTP / SMS_OTP / LINE_OTP), code_hash (SHA-256), destination, expires_at, consumed_at (one-time), attempt_count, max_attempts |


### PR DESCRIPTION
Closes #89
Closes #90

## 問題

`spec/SPEC.md` §3.1 の migration 表に2つの陳腐化があった:

1. **#89**: 表が 023 で停止し、024-033 の10件が未記載（実コード `auth-core/migrations/` には 001-033 の33ファイルが存在）。SPEC.md:20-21 は「code と SPEC が食い違うのはバグ」と宣言しているため契約違反。
2. **#90**: 既存行 008/009/022/023 の説明欄が実SQLと不一致（存在しないカラムの記載、型の誤り、bincode→serde_json 移行未反映、HMAC-signed→DB-backed 移行未反映）。

両 issue は同じ SPEC §3.1 表を対象とするため、同一 PR で処理する。

## 修正内容

### #89（選択肢1採用）— 行の追加
- §3.1 キャプション: `Migrations (23 files)` → `Migrations (33 files)`
- `current head is **023**` → `current head is **033**`
- §3 直前のディレクトリツリー（L119）: `23 SQL files (001 → 023)` → `33 SQL files (001 → 033)`
- §3.1 表に 024-033 の10行を追加

### #90 — 既存行の説明欄修正
- **008 sessions**: `revoked_at`/`last_used_at`/`ip` は存在せず、`invalidated_at`/`last_active_at`/`ip_address`/`return_to`/`csrf_token`/`email`/`tenant_slug`/`roles`/`display_name` が未記載だった。タイムスタンプは `TIMESTAMPTZ` でなく `BIGINT`。実SQLに合わせて全カラムを正確に記載。
- **009 user_mfa**: PK は `user_id` でなく `id UUID`。カラム名も `totp_secret`/`enabled_at` でなく `type`/`secret`/`is_active`/`created_at`。migration 027 が `UNIQUE(user_id, type)` を追加して `ON CONFLICT` upsert を可能にしている旨も追記。
- **022 oidc_flows**: `state` は `HMAC-signed` でなく `VARCHAR UNIQUE`（DB-backed opaque、HMAC-signed stateless からの移行 — `auth-server/src/handlers/oidc.rs:3-6` と CHANGELOG で明記）。`code_verifier_encrypted` (KeyCipher AES-GCM)、`return_to`、`invite_code`、`tenant_id` 等を反映。
- **023 passkey_challenges**: `bincode` → `serde_json` に移行済み（CHANGELOG `[Unreleased]` で明記）。実SQLのコメントは古いまま `bincode` と書かれているが、SPEC は現状の `serde_json` を記載。

## 記載方針

各 migration ファイルのヘッダコメント + `CREATE TABLE` / `ALTER TABLE` / `CREATE INDEX` 文を直接実測し、既存行の文体に合わせて Purpose 欄を記載。シークレット系のカラム（`token_hash`, `code_hash`, `device_code_hash` 等）は「平文保存せず SHA-256 のみ」という設計意図を明示。

## 検証

- 各 migration ファイル（`auth-core/migrations/001-033`）の中身を直接確認
- 表のパイプ数は全行4（=3カラム）で整合、markdown 形式の崩れなし
- ドキュメントのみの変更、ビルド・CI 影響なし、回帰テスト不要

## 人間ゲート

該当なし。仕様変更・破壊的変更・広いリファクタいずれもなし。
- #89 は選択肢1（表に10行追加）を採用。選択肢2（SPEC §3.1 を「実SQLを参照」の一行に圧縮）は SPEC.md:20-21 の宣言と矛盾、選択肢3（表は現状維持）は issue の趣旨に反する。
- #90 は「実SQLに合わせて説明欄を修正」を issue が明示。実コードを正とする方針は明確。

## 範囲外（別 issue で扱う）

- L7（冒頭サマリ）/ L1957（Mermaid 図）/ L2265（付録概要表）の `23 migrations` の包括的陳腐化 → #82（SPEC 固定値陳腐化）で一括処理
- 付録 D.2 sessions の修正はワークツリーで未コミット修正が存在（確認済み、本 issue とは別）

## 外部情報

使用していない。すべてローカルファイル観測。

## LOOP_ROUTE

LOOP_ROUTE: issue-fix
