### PR TITLE
docs(spec): SPEC.md:3 の Version を 0.2.0 → 0.3.0 + [Unreleased] に修正 (#91)

### DIFF
--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1,6 +1,6 @@
 # volta-gateway — Specification
 
-> **Version:** 0.2.0 (workspace) · `tramli = "3.8"` · `tramli-plugins = "3.6.1"`
+> **Version:** 0.3.0 (workspace) · `[Unreleased]` · `tramli = "3.8"` · `tramli-plugins = "3.6.1"`
 > **Scope:** End-to-end specification for the `volta-gateway` Cargo workspace —
 > covering the 5-crate layout, the dual Rust/Java posture, the per-request
 > FlowEngine, the 96-route `auth-server` Axum router, the 5 rate-limited merge


### PR DESCRIPTION
Closes #91

## 問題

`spec/SPEC.md:3` が `Version: 0.2.0` で止まっていた。しかし:

- 実 `git tag` は **v0.3.0** (2026-04-17, CHANGELOG に対応)
- `[Unreleased]` セクションで Phase 3-5 機能（DPoP / OIDC logout / account linking / risk step-up / token exchange 等）が大量追加済み

3 つの異なる「現在バージョン」(Cargo=0.1.0 / CHANGELOG=0.3.0 / SPEC=0.2.0) が併存する問題 (#87) のうち、SPEC.md:3 単独を扱う。

## 修正内容

`SPEC.md:3` の1行のみ:

```diff
-> **Version:** 0.2.0 (workspace) · `tramli = "3.8"` · `tramli-plugins = "3.6.1"`
+> **Version:** 0.3.0 (workspace) · `[Unreleased]` · `tramli = "3.8"` · `tramli-plugins = "3.6.1"`
```

- `0.2.0` → `0.3.0`（実tag の最新）
- `[Unreleased]` を付記（CHANGELOG の [Unreleased] セクションが存在するため）
- `tramli = "3.8"` / `tramli-plugins = "3.6.1"` は実 `Cargo.toml`（gateway/Cargo.toml:32-33, auth-core/Cargo.toml:44-45）と一致するため**変更なし**

## 人間ゲート

該当なし。仕様変更・破壊的変更・広いリファクタいずれもなし。
- issue #91 は「0.3.0 を正とするか、次リリース（Unreleased）に揃えるか」を人間判断待ちとしていたが、推奨対応は「`SPEC.md:3` を `0.3.0 (workspace) / [Unreleased]` のように更新」。両方を併記する形で推奨対応を実装。
- 1行のみの変更、ドキュメントのみ、ビルド・テスト影響なし。

## 範囲外（別 issue で扱う）

- `Cargo.toml` 各 crate の `version = "0.1.0"` 陳腐化 → #87
- SPEC/CHANGELOG の固定値全体の陳腐化（routes, merges, handlers 等）→ #82
- テスト数の陳腐化 → #99

## 検証

- `git diff --stat` → `spec/SPEC.md | 2 +-`（1行変更）
- `git tag --list | tail` → v0.3.0 が最新
- `grep "tramli" gateway/Cargo.toml auth-core/Cargo.toml` → 3.8 / 3.6.1（SPEC 記載と一致）
- ドキュメントのみの変更、回帰テスト不要

## 外部情報

使用していない。すべてローカルファイル観測。

## LOOP_ROUTE

LOOP_ROUTE: issue-fix