### PR TITLE
docs: backlog の #37 #39 を 🟡Open → ✅Done に修正 (実態はCLOSED) (#85)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -116,8 +116,8 @@ gateway の `path_prefix: /saml/` + `public: true` で Java に転送。
 
 | # | Issue | Status |
 |---|-------|--------|
-| #37 | Streaming compression | 🟡 Open |
-| #39 | Access log file separation | 🟡 Open |
+| #37 | Streaming compression | ✅ Done |
+| #39 | Access log file separation | ✅ Done |
 | #43 | ACME DNS-01 | ✅ Done (Phase 1+2) |
 | #44 | Docker labels source | ✅ Done |
 | #45 | Getting Started guide | ✅ Done |


### PR DESCRIPTION
Closes #85

## 問題

`docs/backlog.md:119-120` の「Open — GitHub Issues」表が:
- `#37 Streaming compression` → 🟡 Open
- `#39 Access log file separation` → 🟡 Open

と陳腐化していた。実際は両 issue とも GitHub 上で **CLOSED** 済み。

## 事実確認

```
$ gh issue view 37 --json state,title
{"state":"CLOSED","title":"Streaming compression with async-compression"}

$ gh issue view 39 --json state,title
{"state":"CLOSED","title":"Access log separation: dedicated file output"}
```

`CHANGELOG.md:102`（[0.2.0] セクション）にも:
```
- **gateway** (`b62498d`): streaming compression (#37), access-log file
  separation (#39), config schema v3 (#55).
```
と完了記載あり。`README.md` の features 表でも両者は完了扱い。

## 修正内容

`docs/backlog.md:119-120` の2行のみ:

```diff
-| #37 | Streaming compression | 🟡 Open |
-| #39 | Access log file separation | 🟡 Open |
+| #37 | Streaming compression | ✅ Done |
+| #39 | Access log file separation | ✅ Done |
```

同表の他 issue（#43〜#47）は既に ✅ Done 表記のため、これで表内の表記が統一される。

## 人間ゲート

該当なし。仕様変更・破壊的変更・広いリファクタいずれもなし。
- issue #85 は「docs 整理のみでコード変更不要」と明記、推奨対応「backlog を CHANGELOG と照合して更新」を実施。
- backlog.md に他の陳腐化（#100: 4 crates → 5, #99: テスト数）があるが、本 issue は #37/#39 の status 陳腐化単独を扱うため範囲外。

## 範囲外（別 issue で扱う）

- backlog.md:26 の `Crates: 4` 陳腐化 → #100
- backlog.md:25 のテスト数陳腐化 → #99

## 検証

- `git diff --stat` → `docs/backlog.md | 4 +-/4`（2行変更）
- `gh issue view 37/39` → 両方 CLOSED
- `grep "streaming compression\|access-log" CHANGELOG.md` → [0.2.0] に完了記載
- ドキュメントのみの変更、回帰テスト不要

## 外部情報

使用していない。GitHub issue 状態は `gh issue view` で直接確認。

## LOOP_ROUTE

LOOP_ROUTE: issue-fix