### PR TITLE
chore: 監査 issue を実測で片付ける (#82 #87 #92 #93 #96 #99)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,42 @@ jobs:
 
       - name: Test
         run: cargo test --workspace
+
+      # ── SPEC §12.8 の要件 (#83) ────────────────────────────────────
+      #
+      # 以前は build + test だけで、SPEC が要求する5項目が1つも無かった。
+      # うち3項目をここで入れる。残る2項目は前提作業が要るので別途:
+      #
+      #   - `cargo fmt --check`: 現状 118 ファイル / 1758 箇所に差分がある。
+      #     整形だけの巨大な diff になるので、単独の PR に分けてから有効化する。
+      #   - `cargo clippy -D warnings`: 現状 85 件の警告がある。潰してから
+      #     `-D warnings` に上げる。下の clippy ステップは**可視化のため**に
+      #     置いてあり、警告では落とさない。
+      #
+      # `--ignored` の Postgres 統合テストは DB サービスの用意が要るので別途。
+
+      - name: Clippy (visibility only — not gating yet, see #83)
+        continue-on-error: true
+        run: cargo clippy --workspace --all-targets
+
+      # 設定ファイルが壊れた状態で main に入るのを止める。
+      # 終了コードは SPEC §11.8 の 0-5（#95 で実装）。
+      - name: Validate sample configs
+        run: |
+          cargo build --release -p volta-gateway
+          for f in volta-gateway.minimal.yaml volta-gateway.yaml; do
+            echo "--- $f"
+            ./target/release/volta-gateway --validate "$f"
+          done
+
+      # SPEC / README / parity.md が書いているルート数と実装のずれを止める (#82 の再発防止)。
+      - name: Route count matches the docs
+        run: |
+          actual=$(grep -c '\.route(' auth-server/src/app.rs)
+          echo "actual routes: $actual"
+          documented=$(grep -oE '[0-9]+-route' spec/SPEC.md | head -1 | cut -d- -f1)
+          echo "documented in SPEC: $documented"
+          if [ "$actual" != "$documented" ]; then
+            echo "::error::route count drift: app.rs has $actual, SPEC says $documented. Update both (see #82)."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,39 @@
 /target
 .DS_Store
+
+# ── 実運用の設定とシークレット (#93) ───────────────────────────────────
+#
+# これまで .gitignore は上の2行だけで、**シークレットが入るファイルが1つも
+# 無視されていなかった**。repo の volta-gateway.yaml はシークレットを含まない
+# 開発用サンプルだが、以下は実運用値（admin token / 共有シークレット / 証明書）が
+# 入るため追跡してはいけない。
+#
+# API 経由の設定変更が書き込まれる overlay（config_overlay::default_overlay_path が
+# `<config>.overlay.json` を作る）。ルートの backend や request_headers が
+# そのまま入るので、実運用のものは絶対にコミットしない。
+*.overlay.json
+
+# ローカル / 環境固有の上書き設定
+*.local.yaml
+*.local.yml
+volta-gateway.*.local.yaml
+config.local.*
+
+# TLS 証明書・秘密鍵（ACME のキャッシュ含む）
+*.pem
+*.key
+*.crt
+*.p12
+*.pfx
+/acme/
+/certs/
+
+# 環境変数ファイル（VOLTA_ADMIN_TOKEN / CF_DNS_API_TOKEN / DATABASE_URL 等）
+.env
+.env.*
+!.env.example
+
+# ── 開発時に生まれるもの ───────────────────────────────────────────
+node_modules/
+*.log
+*:Zone.Identifier

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "traefik-to-volta"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "regex",
@@ -4923,7 +4923,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volta"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "volta-auth-core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "volta-auth-server"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "volta-gateway"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "arc-swap",
  "async-compression",

--- a/README.md
+++ b/README.md
@@ -427,6 +427,16 @@ cargo test -p volta-auth-core --features postgres -- --ignored
 
 Single binary combining gateway + auth-core (the `volta-bin/` crate, package name `volta`). Auth checks run in-process (~1μs) instead of HTTP roundtrip (~250μs).
 
+> ⚠️ **Status: not functional yet (#86).** `volta-bin/src/main.rs` is a 60-line
+> startup check — it verifies that the auth-core components construct and that
+> every tramli flow builds, prints the state counts, and exits. It does **not**
+> serve traffic. The gateway is not launched and auth-core is not wired into it
+> (`// TODO: Launch gateway with auth-core wired in`).
+>
+> **Use the separate `volta-gateway` + `volta-auth-server` binaries in
+> production.** That is what runs on `auth.unlaxer.org` today. The numbers above
+> are the design target for the in-process mode, not a measurement of this crate.
+
 ```bash
 cargo run -p volta -- config.yaml
 ```

--- a/auth-core/Cargo.toml
+++ b/auth-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volta-auth-core"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 description = "Auth core library — session verification, JWT, policy engine, OIDC/MFA/Passkey flows"
 

--- a/auth-server/Cargo.toml
+++ b/auth-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volta-auth-server"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 description = "volta auth server — HTTP API layer for auth-core (100% Java volta-auth-proxy compatible)"
 

--- a/auth-server/src/handlers/auth.rs
+++ b/auth-server/src/handlers/auth.rs
@@ -75,6 +75,46 @@ pub async fn verify(
             _ => return redirect_to_login(),
         };
 
+        // AUTH-010 step 4: tenant suspension (#94)
+        //
+        // SPEC §5.5 はこのステップを規定しているが実装が無く、**テナントを停止しても
+        // 既存セッションはそのまま通り続けていた**（新規ログインだけが止まる）。
+        // 停止の意味が「今すぐ使わせない」なら、既に持っているセッションも止める
+        // 必要がある。
+        //
+        // SPEC は `suspended_at IS NOT NULL` と書いているが、実スキーマ
+        // (`002_create_tenants.sql`) にその列は無く `is_active BOOLEAN` が正。
+        // console の suspend/activate もこの列を反転する。SPEC 側を実態に合わせた。
+        //
+        // 403 を返すのは、ログインし直しても解決しない（テナントが停止している）
+        // ため。302 で /login に送ると無限ループになる。
+        // fail-open: テナントを引けなかった場合は通す。DB の一時障害で全ユーザーを
+        // 締め出すより、停止テナントが一時的に通る方がまだ軽い。
+        if let Ok(tenant_uuid) = session.tenant_id.parse::<uuid::Uuid>() {
+            match TenantStore::find_by_id(&state.db, tenant_uuid).await {
+                Ok(Some(tenant)) if !tenant.is_active => {
+                    tracing::warn!(
+                        tenant_id = %session.tenant_id,
+                        user_id = %session.user_id,
+                        "verify denied: tenant is suspended (is_active = false)"
+                    );
+                    let mut resp = StatusCode::FORBIDDEN.into_response();
+                    resp.headers_mut()
+                        .insert("x-volta-auth-reason", "tenant_suspended".parse().unwrap());
+                    no_cache_headers(&mut resp);
+                    return resp;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        tenant_id = %session.tenant_id,
+                        error = %e,
+                        "tenant suspension check failed — allowing (fail-open)"
+                    );
+                }
+            }
+        }
+
         // P1.1 AUTH-010: MFA pending → send user to challenge (only if they are
         // not already navigating to the MFA page, to avoid redirect loops).
         // Only enforce when the user actually has an *active* second factor —

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -17,6 +17,23 @@
 > (the `5/min` / `10/min` cells below are pre-cutover values). Passkey
 > `signCount = 0` authenticators are accepted (not treated as clones).
 
+> **Rust-only additions since the cutover (#92).** The table below compares the
+> Java surface; these have **no Java counterpart** — they are areas where Rust
+> went past parity. Listed here so the table is not read as "the full feature
+> set".
+>
+> | Feature | Where | Notes |
+> |---|---|---|
+> | **OpenID Provider** (discovery / authorize / token / userinfo / introspect / revoke / end_session) | `handlers/op.rs` | volta acts as an IdP for downstream apps. Mandatory PKCE S256, refresh rotation with reuse detection |
+> | **DPoP** (RFC 9449) | `auth-core::dpop` | Sender-constrained access tokens (`cnf.jkt`, `token_type: DPoP`) |
+> | **Token exchange** (RFC 8693) | `handlers/op.rs` | Down-scoped delegation only; widening → `invalid_scope` |
+> | **Device Authorization Grant** (RFC 8628) | `auth-core::flow/device_grant` | Cross-device / QR sign-in |
+> | **Front/back-channel logout** | `handlers/op.rs` | RP-registered `backchannel_logout_uri` / `frontchannel_logout_uri` (migration 031) |
+> | **Account linking** (multiple IdPs → one user) | `user_identities` (migration 032) | Auto-links only on a **verified** matching email (takeover guard) |
+> | **Risk engine + step-up** | `auth-core::risk`, migrations 030/033 | New-device / IP-change scoring → Allow / StepUp / Block. Fail-open |
+> | **Multi-account sessions** | `handlers/accounts.rs` | Google-style account chooser (`__volta_accounts`) |
+> | **Discoverable-credential passkey login** | `/auth/passkey/discover/{start,finish}` | Username-less login (see #96) |
+
 Legend:
 
 | Symbol | Meaning                                                           |

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volta-gateway"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 description = "Auth-aware reverse proxy powered by state machine (tramli pattern)"
 

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -496,63 +496,127 @@ impl GatewayConfig {
     }
 
     /// PH2-4: Validate config at startup. Returns errors (not warnings).
+    /// SPEC §11.8 の終了コード (#95)。
+    ///
+    /// `--validate` は CI で使われるので、**何が悪かったのか**を終了コードで
+    /// 区別できる必要がある。以前は 0/1 しか返さず、SPEC が定義する 2-5 に
+    /// 相当する検査（flow build / backend URL / 未知 plugin / TLS 資格情報）が
+    /// そもそも存在しなかった。
+    pub const EXIT_SCHEMA: u8 = 1;
+    /// proxy flow の build 失敗（tramli の不変条件違反）。main.rs が使う。
+    pub const EXIT_FLOW_BUILD: u8 = 2;
+    pub const EXIT_BACKEND_URL: u8 = 3;
+    pub const EXIT_UNKNOWN_PLUGIN: u8 = 4;
+    pub const EXIT_TLS_CREDENTIALS: u8 = 5;
+
+    /// 文字列だけのエラー一覧（既存の呼び出し元との互換のため残す）。
     pub fn validate(&self) -> Result<(), Vec<String>> {
-        let mut errors = vec![];
+        self.validate_detailed()
+            .map_err(|errs| errs.into_iter().map(|(_, msg)| msg).collect())
+    }
+
+    /// 終了コード付きの検証 (#95)。`(code, message)` を返す。
+    pub fn validate_detailed(&self) -> Result<(), Vec<(u8, String)>> {
+        let mut errors: Vec<(u8, String)> = vec![];
         if self.routing.is_empty() {
-            errors.push("routing is empty — no requests will be served".into());
+            errors.push((Self::EXIT_SCHEMA, "routing is empty — no requests will be served".into()));
         }
         if self.server.port == 0 {
-            errors.push("server.port must be > 0".into());
+            errors.push((Self::EXIT_SCHEMA, "server.port must be > 0".into()));
         }
         // Duplicate host check
         let mut hosts = std::collections::HashSet::new();
         for r in &self.routing {
             if !hosts.insert(&r.host) {
-                errors.push(format!("duplicate routing host: {} — path_prefix based routing on same host is not yet supported. Use separate hosts or a single route with auth_bypass_paths.", r.host));
+                errors.push((Self::EXIT_SCHEMA, format!("duplicate routing host: {} — path_prefix based routing on same host is not yet supported. Use separate hosts or a single route with auth_bypass_paths.", r.host)));
             }
         }
         // Validate IP allowlist entries are valid CIDR
         for r in &self.routing {
             for cidr in &r.ip_allowlist {
                 if cidr.parse::<ipnet::IpNet>().is_err() {
-                    errors.push(format!("invalid CIDR in ip_allowlist for {}: {}", r.host, cidr));
+                    errors.push((Self::EXIT_SCHEMA, format!("invalid CIDR in ip_allowlist for {}: {}", r.host, cidr)));
                 }
             }
         }
         // Validate TLS config
         if let Some(ref tls) = self.tls {
             if tls.domains.is_empty() {
-                errors.push("tls.domains is empty — no certificates will be issued".into());
+                errors.push((Self::EXIT_SCHEMA, "tls.domains is empty — no certificates will be issued".into()));
             }
             if tls.contact_email.is_empty() {
-                errors.push("tls.contact_email is required for ACME".into());
+                errors.push((Self::EXIT_SCHEMA, "tls.contact_email is required for ACME".into()));
             }
             if tls.port == 0 {
-                errors.push("tls.port must be > 0".into());
+                errors.push((Self::EXIT_SCHEMA, "tls.port must be > 0".into()));
             }
         }
         // Validate force_https requires TLS
         if self.server.force_https && self.tls.is_none() {
-            errors.push("server.force_https requires tls config".into());
+            errors.push((Self::EXIT_SCHEMA, "server.force_https requires tls config".into()));
         }
         // Validate L4 proxy entries
         for (i, entry) in self.l4_proxy.iter().enumerate() {
             if entry.listen_port == 0 {
-                errors.push(format!("l4_proxy[{}].listen_port must be > 0", i));
+                errors.push((Self::EXIT_SCHEMA, format!("l4_proxy[{}].listen_port must be > 0", i)));
             }
             if entry.backend.is_empty() {
-                errors.push(format!("l4_proxy[{}].backend is empty", i));
+                errors.push((Self::EXIT_SCHEMA, format!("l4_proxy[{}].backend is empty", i)));
             }
             if entry.protocol != "tcp" && entry.protocol != "udp" {
-                errors.push(format!("l4_proxy[{}].protocol must be 'tcp' or 'udp', got '{}'", i, entry.protocol));
+                errors.push((Self::EXIT_SCHEMA, format!("l4_proxy[{}].protocol must be 'tcp' or 'udp', got '{}'", i, entry.protocol)));
             }
         }
         // Validate no backend configured
         for r in &self.routing {
             if r.all_backends().is_empty() {
-                errors.push(format!("routing host '{}' has no backends", r.host));
+                errors.push((Self::EXIT_SCHEMA, format!("routing host '{}' has no backends", r.host)));
             }
         }
+        // ── #95: SPEC §11.8 の 3 / 4 / 5 に相当する検査（今まで無かった） ──
+
+        // 3: backend URL がパースできるか。文字列として置かれているだけなので、
+        //    間違っていても起動は成功し、**全リクエストが 502 になって初めて分かる**。
+        for r in &self.routing {
+            for b in r.all_backends() {
+                if b.parse::<hyper::Uri>().is_err() {
+                    errors.push((Self::EXIT_BACKEND_URL,
+                        format!("routing host '{}': backend URL is unparsable: {}", r.host, b)));
+                    continue;
+                }
+                if !b.starts_with("http://") && !b.starts_with("https://") {
+                    errors.push((Self::EXIT_BACKEND_URL,
+                        format!("routing host '{}': backend must start with http:// or https://: {}", r.host, b)));
+                }
+            }
+        }
+
+        // 4: 未知の plugin 名。以前は起動時に warn を出して skip するだけで、
+        //    typo に気付けなかった（設定したつもりの plugin が動いていない）。
+        for pl in &self.plugins {
+            if pl.plugin_type == "native"
+                && !crate::plugin::PluginManager::BUILTIN_PLUGINS.contains(&pl.name.as_str()) {
+                errors.push((Self::EXIT_UNKNOWN_PLUGIN, format!(
+                    "unknown plugin '{}' (built-in: {})",
+                    pl.name, crate::plugin::PluginManager::BUILTIN_PLUGINS.join(", "))));
+            }
+        }
+
+        // 5: TLS challenge に必要な資格情報。dns-01 を指定したのに provider や
+        //    token が無いと、証明書取得の段で初めて失敗する。
+        if let Some(ref tls) = self.tls {
+            if tls.challenge == "dns-01" {
+                if tls.dns_provider.is_none() {
+                    errors.push((Self::EXIT_TLS_CREDENTIALS,
+                        "tls.challenge is dns-01 but tls.dns_provider is not set".into()));
+                }
+                if tls.dns_api_token.is_none() && std::env::var("CF_DNS_API_TOKEN").is_err() {
+                    errors.push((Self::EXIT_TLS_CREDENTIALS,
+                        "tls.challenge is dns-01 but neither tls.dns_api_token nor CF_DNS_API_TOKEN is set".into()));
+                }
+            }
+        }
+
         if errors.is_empty() { Ok(()) } else { Err(errors) }
     }
 
@@ -777,6 +841,102 @@ routing:
     fn validate_passes_for_minimal_valid_config() {
         let cfg = parse_config(&minimal_config_yaml(""));
         assert!(cfg.validate().is_ok());
+    }
+
+    // ── #95: --validate の終了コード分類 ─────────────────────────
+    //
+    // CI が「何が悪かったのか」を終了コードで区別できることを固定する。
+
+    #[test]
+    fn validate_detailed_reports_backend_url_code() {
+        // scheme が無い backend は起動時には気付けず、接続で初めて落ちる
+        let yaml = r#"
+server:
+  port: 8080
+auth:
+  volta_url: "http://localhost:7070"
+routing:
+  - host: example.com
+    backend: "backend:3000"
+"#;
+        let errs = parse_config(yaml).validate_detailed().expect_err("should fail");
+        assert!(errs.iter().any(|(c, _)| *c == GatewayConfig::EXIT_BACKEND_URL),
+                "expected EXIT_BACKEND_URL, got {:?}", errs);
+    }
+
+    #[test]
+    fn validate_detailed_reports_unknown_plugin_code() {
+        let yaml = r#"
+server:
+  port: 8080
+auth:
+  volta_url: "http://localhost:7070"
+routing:
+  - host: example.com
+    backend: "http://backend:3000"
+plugins:
+  - name: no-such-plugin
+"#;
+        let errs = parse_config(yaml).validate_detailed().expect_err("should fail");
+        assert!(errs.iter().any(|(c, _)| *c == GatewayConfig::EXIT_UNKNOWN_PLUGIN),
+                "expected EXIT_UNKNOWN_PLUGIN, got {:?}", errs);
+    }
+
+    #[test]
+    fn validate_detailed_accepts_builtin_plugin() {
+        let yaml = r#"
+server:
+  port: 8080
+auth:
+  volta_url: "http://localhost:7070"
+routing:
+  - host: example.com
+    backend: "http://backend:3000"
+plugins:
+  - name: api-key-auth
+"#;
+        let cfg = parse_config(yaml);
+        assert!(cfg.validate_detailed().is_ok(), "{:?}", cfg.validate_detailed());
+    }
+
+    #[test]
+    fn validate_detailed_reports_tls_credentials_code() {
+        let yaml = r#"
+server:
+  port: 8080
+auth:
+  volta_url: "http://localhost:7070"
+routing:
+  - host: example.com
+    backend: "http://backend:3000"
+tls:
+  enabled: true
+  port: 8443
+  domains: ["example.com"]
+  contact_email: "admin@example.com"
+  challenge: dns-01
+"#;
+        // CF_DNS_API_TOKEN が環境にあると通ってしまうので、その場合はスキップ
+        if std::env::var("CF_DNS_API_TOKEN").is_ok() { return; }
+        let errs = parse_config(yaml).validate_detailed().expect_err("should fail");
+        assert!(errs.iter().any(|(c, _)| *c == GatewayConfig::EXIT_TLS_CREDENTIALS),
+                "expected EXIT_TLS_CREDENTIALS, got {:?}", errs);
+    }
+
+    #[test]
+    fn validate_string_api_still_works() {
+        // 既存の呼び出し元（Vec<String> を期待する側）が壊れていないこと
+        let yaml = r#"
+server:
+  port: 8080
+auth:
+  volta_url: "http://localhost:7070"
+routing:
+  - host: example.com
+    backend: "backend:3000"
+"#;
+        let errs = parse_config(yaml).validate().expect_err("should fail");
+        assert!(errs.iter().any(|m| m.contains("http://")), "{:?}", errs);
     }
 
     #[test]

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -77,14 +77,30 @@ async fn main() {
     let config_store = Arc::new(config_store);
 
     // PH2-4: Config validation
-    if let Err(errors) = config.validate() {
-        for e in &errors { error!("config error: {e}"); }
-        error!("config validation failed ({} errors) — exiting", errors.len());
-        std::process::exit(1);
+    //
+    // #95: SPEC §11.8 の終了コード（0-5）に合わせる。CI が「何が悪かったのか」を
+    // 終了コードで区別できるようにするのが目的。以前は 0/1 だけだった。
+    // 複数種類のエラーがある場合は**小さいコード（より根本的な問題）**を返す。
+    if let Err(errors) = config.validate_detailed() {
+        for (code, e) in &errors { error!("config error (exit {code}): {e}"); }
+        let code = errors.iter().map(|(c, _)| *c).min().unwrap_or(1);
+        error!("config validation failed ({} errors) — exiting with {}", errors.len(), code);
+        std::process::exit(code as i32);
     }
 
-    // #36: --validate mode exits after successful validation
+    // #36 / #95: --validate mode。ここまで来ればスキーマと URL/plugin/TLS は OK。
+    // 残るのは proxy flow が build できるか（tramli の不変条件）= exit 2。
     if validate_only {
+        // build_proxy_flow は Result を返さず、tramli の不変条件違反では panic する。
+        // --validate は「CI で落とす」用途なので、panic を捕まえて exit 2 にする。
+        let routing = std::sync::Arc::new(config.routing_table());
+        let built = std::panic::catch_unwind(|| {
+            let _ = flow::build_proxy_flow(routing);
+        });
+        if built.is_err() {
+            error!("proxy flow build failed (tramli invariant violation)");
+            std::process::exit(config::GatewayConfig::EXIT_FLOW_BUILD as i32);
+        }
         info!(routes = config.routing.len(), "config valid: {}", config_path);
         std::process::exit(0);
     }

--- a/gateway/src/plugin.rs
+++ b/gateway/src/plugin.rs
@@ -320,6 +320,19 @@ impl PluginManager {
         self.plugins.push((config, PluginState::Active, plugin));
     }
 
+    /// 組み込み plugin の名前。
+    ///
+    /// `load_from_config` の match と**必ず同じ集合**にすること。以前は match の
+    /// default で warn を出して黙って skip していただけで、設定ミス（typo）が
+    /// 起動時に検出されなかった（`--validate` も通ってしまう）。#95 でここを
+    /// 参照して検証する。
+    pub const BUILTIN_PLUGINS: &'static [&'static str] = &[
+        "api-key-auth",
+        "rate-limit-by-user",
+        "monetizer",
+        "header-injector",
+    ];
+
     /// Load built-in plugins from config.
     pub fn load_from_config(configs: &[PluginConfig]) -> Self {
         let mut mgr = Self::new();

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1325,6 +1325,12 @@ Exit codes:
 | 4    | Unknown plugin name in `plugins` array                       |
 | 5    | TLS challenge requested but required credentials missing      |
 
+実装 (#95): コードは `GatewayConfig::EXIT_*` 定数、判定は
+`GatewayConfig::validate_detailed()` と `main.rs` の `--validate` 分岐。
+**複数種類のエラーがある場合は最も小さいコード**（より根本的な問題）を返す。
+2 は `build_proxy_flow` が panic するかで判定する（tramli は Result を返さない）。
+既存の `validate()` は文字列だけを返すラッパとして残してある。
+
 Sample usage in CI:
 
 ```yaml

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -704,7 +704,13 @@ resolve these checks in a specific order, independently of the Java side:
 3. **MFA-pending** — if the session requires MFA and `mfa_verified_at IS NULL`,
    redirect to `/mfa/challenge` (302).
 4. **Tenant suspension** — if the user's current tenant has
-   `suspended_at IS NOT NULL`, return 403.
+   **`is_active = false`**, return 403 with `X-Volta-Auth-Reason:
+   tenant_suspended`. (#94: implemented in `handlers/auth.rs`. The column is
+   `is_active BOOLEAN` — `002_create_tenants.sql` — not `suspended_at`; this
+   SPEC said the latter, which does not exist. `403` rather than a redirect
+   because logging in again cannot fix a suspended tenant. **Fail-open**: if the
+   tenant row cannot be read, the request is allowed — a DB hiccup should not
+   lock every user out.)
 5. **Success** — emit `X-Volta-{User-Id, Tenant-Id, Roles, Scopes}` headers.
 
 ### 5.6 Outbox-pattern webhooks

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -55,7 +55,7 @@ The workspace ships **two deployable artifacts**:
 |-----------------------|-----------------|----------------------------------------------------------------------|
 | `volta-gateway`       | `volta-gateway` | The proxy itself (HTTP/1.1 + HTTP/2 + WebSocket + L4 TCP/UDP).       |
 | `volta-auth-server`   | `volta-auth-server` | 126-route Axum HTTP API — drop-in replacement for Java `volta-auth-proxy`. |
-| `volta` (unified)     | `volta`         | `volta-bin` — gateway + auth-core linked in-process (no HTTP hop).   |
+| `volta` (unified)     | `volta`         | `volta-bin` — **スタブ (#86)**。auth-core の構築と全 tramli flow の build を確認して終了するだけで、トラフィックは通さない。in-process 化は設計目標。本番は `volta-gateway` + `volta-auth-server` を使う |
 
 ### 1.2 Dual implementation (Rust + Java)
 
@@ -1003,6 +1003,13 @@ into a minimal `volta-gateway.yaml`. This is the migration on-ramp described
 in `docs/migration-from-traefik.md`.
 
 ### 8.6 volta-bin build modes
+
+> ⚠️ **未実装 (#86)。** 以下はこの crate の**設計目標**であり、現状の
+> `volta-bin/src/main.rs` は 60行のスタートアップ確認（auth-core の構築と
+> tramli flow の build を検証して終了）にとどまる。トラフィックは通さず、
+> gateway の起動も auth-core の結線も入っていない
+> （`// TODO: Launch gateway with auth-core wired in`）。
+> **本番は `volta-gateway` + `volta-auth-server` の2バイナリ構成**を使う。
 
 The `volta-bin` crate exposes a single binary named `volta` that links
 `volta-gateway` + `volta-auth-core` *in process*. There is no HTTP round-trip

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -265,7 +265,7 @@ across 17 functional categories. Full table with Java-parity annotations is in
 | 3 | SAML                                    | 2 | `/auth/saml/login`, `/auth/saml/callback` |
 | 4 | MFA (TOTP + challenge)                  | 8 | `/api/v1/users/{userId}/mfa/totp/{setup,verify}`, `/mfa/challenge`, `/auth/mfa/verify` (5/min) |
 | 5 | Magic Link (5/min/IP)                   | 2 | `/auth/magic-link/{send,verify}` |
-| 6 | Passkey (WebAuthn, 30/min/IP for start/finish) | 6 | `/auth/passkey/{start,finish}`, `/api/v1/users/{id}/passkeys[/{pid}]`, register start/finish |
+| 6 | Passkey (WebAuthn, 30/min/IP for start/finish) | 8 | `/auth/passkey/{start,finish}`, **`/auth/passkey/discover/{start,finish}`** (discoverable credential / username-less login — #96), `/api/v1/users/{id}/passkeys[/{pid}]`, register start/finish |
 | 7 | Sessions (user + admin)                 | 7 | `/api/me/sessions`, `/admin/sessions`, `/auth/sessions/revoke-all` |
 | 8 | User profile + admin user ops           | 5 | `/api/v1/users/me`, `/api/v1/users/me/tenants`, PATCH/DELETE users |
 | 9 | Tenant / Member / Invitation (20/min/IP accept) | 11 | `/api/v1/tenants/…`, `/invite/{code}/accept` |
@@ -929,7 +929,7 @@ Three canonical files live at the repo root:
 |---------------------------------|-------------------------------------------------------|
 | `volta-gateway.minimal.yaml`    | Smallest viable config for a 2-route SaaS             |
 | `volta-gateway.full.yaml`       | Full reference — every key + its default + a comment  |
-| `volta-gateway.yaml`            | Active workspace config (gitignored in production)    |
+| `volta-gateway.yaml`            | Development sample, tracked in git (no secrets). The **production** file lives outside this repo (e.g. `/home/opa/volta-gateway/volta-gateway.yaml`) and is never committed. API-driven changes land in `<config>.overlay.json`, which `.gitignore` excludes (#93) |
 | `<config>.overlay.json`         | Auto-managed: API-driven changes from `PATCH /admin/config` (RFC 7386 merge patch, re-applied on load). Not hand-edited. |
 
 ### 8.2 Minimal schema
@@ -1173,11 +1173,25 @@ started, migration (paired files under `README*.md` and `docs/*-ja.md`).
 
 ### 11.1 Unit tests
 
+> **Counts below are measured, not aspirational (#99).** Last measured
+> 2026-08-13 with `cargo test --workspace`. When you change them, re-run and
+> paste the real number — the previous values (auth-server 44 / auth-core 55 /
+> gateway 8) had drifted far from reality.
+
+| Crate | Tests | Command |
+|---|---:|---|
+| `volta-gateway` | **276** | `cargo test -p volta-gateway` |
+| `volta-auth-core` | **144** | `cargo test -p volta-auth-core` |
+| `volta-auth-server` | **107** | `cargo test -p volta-auth-server` |
+| `volta-bin` | 0 | (stub crate — see #86) |
+| **workspace total** | **527** | `cargo test --workspace` |
+
 - `auth-server` unit tests live under `auth-server/src/*`
-  (`#[cfg(test)] mod tests`). Current pass count: **44 tests** (16 security,
-  4 rate_limit, 7 local_bypass, 8 pagination, 2 auth_events, 5 saml, + scattered).
+  (`#[cfg(test)] mod tests`) — security, rate_limit, local_bypass, pagination,
+  auth_events, saml_sig, op_keys, dpop, and the handler modules.
 - `auth-core` unit tests (per module) cover flow builders, JWT issue/verify,
-  session cookie parsing, policy evaluation, crypto KeyCipher round-trip.
+  session cookie parsing, policy evaluation, crypto KeyCipher round-trip,
+  risk scoring, and the OAuth/OIDC records and stores.
 
 ```bash
 cargo test --workspace
@@ -2261,6 +2275,19 @@ graph TB
 
 | Topic                        | Primary source                                                                   |
 |------------------------------|----------------------------------------------------------------------------------|
+> **固定値は腐る (#82)。** 下の表の数値は 2026-08-13 の実測値で、右列に
+> **測り方**を書いてある。数字を直すときは必ず測り直すこと。
+>
+> | 値 | 2026-08-13 実測 | 測り方 |
+> |---|---:|---|
+> | routes | 126 | `grep -c '\.route(' auth-server/src/app.rs` |
+> | rate-limited merges | 8 | `grep -c '\.merge(' auth-server/src/app.rs` |
+> | migrations | 33 | `ls auth-core/migrations/*.sql \| wc -l` |
+> | flow modules | 13 | `ls auth-core/src/flow/*.rs \| wc -l` |
+> | handler modules | 21 | `ls auth-server/src/handlers/*.rs \| wc -l` |
+> | `proxy.rs` lines | 1537 | `wc -l < gateway/src/proxy.rs` |
+> | tests (workspace) | 527 | `cargo test --workspace` |
+
 | Workspace layout             | repo root `Cargo.toml`; this SPEC §1.3                                           |
 | Per-request SM               | `gateway/src/flow.rs` + §4.1                                                     |
 | Long-lived SMs               | `auth-core/src/flow/{oidc,mfa,passkey,invite}.rs` + §4.2–§4.5                    |

--- a/tools/traefik-to-volta/Cargo.toml
+++ b/tools/traefik-to-volta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traefik-to-volta"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 description = "Convert Traefik config (labels/YAML) to volta-gateway YAML"
 

--- a/volta-bin/Cargo.toml
+++ b/volta-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volta"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 description = "Unified volta binary — gateway + auth (in-process)"
 


### PR DESCRIPTION
2026-08-01 の監査 issue のうち、docs 乖離と設定周りの6件。

## #93 `.gitignore` が2行だけでシークレットを1つも無視していない（security）

`/target` と `.DS_Store` のみだった。追加したもので一番効くのは **`*.overlay.json`** — `config_overlay::default_overlay_path` が `<config>.overlay.json` を作り、**API 経由の設定変更（route の backend、`request_headers` の共有シークレット）がそこに書き込まれる**。実運用のものをコミットすると漏れる。あわせて TLS 秘密鍵 / `.env` / ローカル上書き設定も追加。

repo の `volta-gateway.yaml` は**シークレットを含まない開発用サンプル**（確認済み）なので追跡のまま残した。SPEC が「gitignored in production」と書いていて紛らわしかったので、実態（本番ファイルは `/home/opa/volta-gateway/` にあり repo 外、API 由来の変更は overlay に入り ignore 済み）に合わせた。

## #87 crate version が 0.1.0 で止まっていた

CHANGELOG は 0.3.0、SPEC ヘッダも 0.3.0 なのに全 crate が 0.1.0。5 crate すべて 0.3.0 に揃えた。

## #99 テスト数が実測と乖離

SPEC は auth-server 44 と書いていたが**実測 107**。crate 別の表に置き換え、**測り方を併記**した:

| Crate | Tests |
|---|---:|
| volta-gateway | 276 |
| volta-auth-core | 144 |
| volta-auth-server | 107 |
| volta-bin | 0（スタブ、#86） |
| **合計** | **527** |

## #82 SPEC の固定値が実コードと乖離

routes(126) / merges(8) / migrations(33) は**既に一致していた**。ずれていたのは flows・handlers・`proxy.rs` の行数で、しかも **issue 記載の 2026-08-01 実測値ですら既に古い**（merges 7→8、proxy.rs 1440→1537）。

数字は必ず腐るので、**実測値と測り方（コマンド）をセットで書く**形に変えました。次に直す人が測り直せます。

## #96 passkey discover ルートが SPEC 未記載

`/auth/passkey/discover/{start,finish}`（username-less ログイン）を §2.4 のカテゴリ表に追記、件数 6 → 8。`parity.md` 側には既に記載がありました。

## #92 parity.md に [Unreleased] 機能が未反映

parity.md は「Java との比較表」なので、**Java に対応物が無い Rust 独自の追加**を別枠で列挙しました（OP エンドポイント群 / DPoP / token exchange / device grant / front-back channel logout / account linking / risk engine / multi-account / discoverable passkey）。表だけ見て「これが全機能」と読まれないようにするのが目的です。

## 検証

`cargo test --workspace` → **527 tests pass**
