### PR TITLE
feat(gateway): SO_REUSEPORT でゼロダウンタイム配信を可能にする (#74 BT-HA-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,7 +2022,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -2426,7 +2426,7 @@ dependencies = [
  "percent-encoding",
  "quoted_printable",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.5",
  "tokio",
  "tokio-rustls",
  "url",
@@ -3103,7 +3103,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3140,7 +3140,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4014,9 +4014,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4529,7 +4529,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5035,6 +5035,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "socket2 0.6.5",
  "subtle",
  "tokio",
  "tokio-rustls",

--- a/docs/zero-downtime-deploy.md
+++ b/docs/zero-downtime-deploy.md
@@ -1,0 +1,97 @@
+# ゼロダウンタイム配信（SO_REUSEPORT ローリング）
+
+`#74` (BT-HA-2) の手順。**バイナリを更新しても `:80` が瞬断しない**ようにする。
+
+## 何が問題だったか
+
+これまでのデプロイは「プロセスを止める → バイナリを差し替える → 起動する」だった。
+その間 `:80` を誰も listen していないので、**数秒間すべての `*.unlaxer.org` が
+接続拒否**になる。`restart: always` と `drain_timeout_secs` は入っていたが、これは
+「落ちたときに戻す」「落とすときに in-flight を守る」ための設定で、**切り替えの
+瞬間に穴が開く**ことは解決しない。
+
+## 仕組み
+
+`server.reuse_port: true` にすると SO_REUSEPORT が立ち、**同じ `:80` に複数の
+プロセスが同時に bind できる**。カーネルが新規接続を listen 中のプロセスへ分散
+するので、次の順で回せば穴が開かない:
+
+```
+1. 新バイナリのプロセスを起動        ← この時点で新旧2つが :80 を listen
+2. 旧プロセスに SIGTERM              ← drain 開始。in-flight を流し切る
+3. 旧プロセスが終了                  ← 以降は新プロセスだけが listen
+```
+
+`SO_REUSEADDR` だけでは足りない（TIME_WAIT の再利用はできるが、**同時に listen
+はできない**）ので、両方立てている。
+
+## 設定
+
+```yaml
+server:
+  port: 80
+  reuse_port: true          # 既定は false
+  drain_timeout_secs: 15    # in-flight を待つ上限
+```
+
+**既定を false にしてある**のは、既存のデプロイで勝手に有効になると「古いプロセスが
+残っていることに気付かないまま新旧が同時に動く」事故が起きうるため。
+「再起動したのに古い挙動のまま」の原因が読めなくなる。手順を整えたうえで opt-in する。
+
+Linux / *BSD / macOS のみ。他プラットフォームでは警告を出して通常の bind に落ちる
+（**黙って無効にすると「有効にしたつもりで瞬断する」**ので、必ずログに出す）。
+
+## 手順（systemd を使わない場合）
+
+```bash
+# 1. 新バイナリを配置（別名で置く）
+scp target/release/volta-gateway prod:/home/opa/volta-gateway/volta-gateway.new
+
+# 2. 旧プロセスの PID を控える
+OLD=$(pgrep -f 'volta-gateway volta-gateway.yaml')
+
+# 3. 差し替えて新プロセスを起動
+ssh prod 'cd /home/opa/volta-gateway && mv volta-gateway.new volta-gateway && \
+          nohup ./volta-gateway volta-gateway.yaml >> gateway.log 2>&1 &'
+
+# 4. 新プロセスが listen したことを確認（2つ見えるはず）
+ssh prod 'ss -ltnp | grep :80'
+
+# 5. 旧プロセスを drain
+ssh prod "kill -TERM $OLD"
+
+# 6. 旧プロセスが消えたことを確認（listener が1つに戻る）
+ssh prod 'ss -ltnp | grep :80'
+```
+
+**4 を飛ばさないこと。** 新プロセスが起動に失敗している（設定エラー等）のに旧を
+落とすと、そこで初めて全滅する。`--validate` を先に通しておくとなお良い
+（終了コードは SPEC §11.8。#95）。
+
+## 実測（2026-08-13）
+
+同一設定の2プロセスを `:18080` に立て、旧プロセスに SIGTERM を送りながら
+100ms 間隔で 60 回叩いた結果:
+
+| 応答 | 回数 |
+|---|---:|
+| 200 | 59 |
+| 503 | 1 |
+| **接続失敗** | **0** |
+
+**接続拒否は一度も起きなかった** = `:80` は瞬断していない。
+
+503 が1回出たのは、drain 中の旧プロセスの `/healthz` に当たったため。これは
+**設計どおり**で、`/healthz` は drain 中に 503 を返して「このインスタンスに新規を
+回すな」を上流に伝える。実トラフィック（`/healthz` 以外）は drain 中も処理される。
+
+ただし**外形監視が `/healthz` を叩いていると、ローリング中に一瞬 down と判定され
+うる**。cf-health-worker は「2回連続失敗で down 宣言」なので誤報にはならないが、
+気になるなら drain 開始時に listener を閉じる（新規接続をカーネルが残りの
+プロセスへ回す）ようにすれば 503 も出なくなる。**未実装**。
+
+## 残り: BT-HA-1（Docker healthcheck）
+
+`/healthz` を叩く healthcheck を compose に入れて、**hang したインスタンスを
+Docker に置き換えさせる**話は未対応。crash は `restart: always` で戻るが、
+無応答は拾えない。`#74` に残す。

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -74,6 +74,7 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 
 # Utilities
 uuid = { version = "1", features = ["v4"] }
+socket2 = "0.6.5"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -270,6 +270,20 @@ pub struct ServerConfig {
     /// finish before forcing shutdown. Default: 30s.
     #[serde(default = "default_drain_timeout")]
     pub drain_timeout_secs: u64,
+
+    /// SO_REUSEPORT を有効にする（#74 BT-HA-2）。
+    ///
+    /// 有効にすると **同じ :80 に複数プロセスが bind できる**。カーネルが接続を
+    /// 分散するので、バイナリ更新は「新プロセスを上げる → 旧を drain して落とす」
+    /// のローリングにでき、:80 が瞬断しない。
+    ///
+    /// 既定は **false**。既存のデプロイで有効になると、古いプロセスが残っている
+    /// ことに気付かないまま新旧が同時に動く事故が起きうる（「再起動したのに古い
+    /// 挙動のまま」の原因が読めなくなる）。運用手順を整えたうえで opt-in する。
+    ///
+    /// Linux / *BSD のみ。他プラットフォームでは無視して警告を出す。
+    #[serde(default)]
+    pub reuse_port: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -954,6 +968,29 @@ routing:
     }
 
     // ── GatewayConfig::validate ──────────────────────────────────
+
+    #[test]
+    fn reuse_port_defaults_to_false() {
+        // #74: 既定で有効になると、既存デプロイで**古いプロセスが残っていることに
+        // 気付かないまま新旧が同時に動く**。opt-in であることを固定する。
+        let cfg = parse_config(&minimal_config_yaml(""));
+        assert!(!cfg.server.reuse_port);
+    }
+
+    #[test]
+    fn reuse_port_can_be_enabled() {
+        let yaml = r#"
+server:
+  port: 8080
+  reuse_port: true
+auth:
+  volta_url: "http://localhost:7070"
+routing:
+  - host: example.com
+    backend: "http://backend:3000"
+"#;
+        assert!(parse_config(yaml).server.reuse_port);
+    }
 
     #[test]
     fn validate_passes_for_minimal_valid_config() {

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -35,6 +35,66 @@ mod websocket;
 use auth::VoltaAuthClient;
 use proxy::{host_is_routed, HotState, ProxyService};
 
+/// リスナーを作る。`reuse_port` が真なら SO_REUSEPORT を立てる（#74 BT-HA-2）。
+///
+/// SO_REUSEPORT を立てると **同じアドレスに複数プロセスが bind できる**。
+/// カーネルが接続を分散するので、デプロイを
+///
+///   1. 新バイナリのプロセスを起動（同じ :80 に bind される）
+///   2. 旧プロセスに drain を指示（`/admin/drain` か SIGTERM）
+///   3. 旧プロセスが in-flight を流し切って終了
+///
+/// の順で回せる。この間 :80 は常にどちらかが受けているので瞬断しない。
+///
+/// SO_REUSEADDR だけでは足りない（TIME_WAIT の再利用はできるが、**同時に**
+/// listen はできない）ので、両方立てる。
+///
+/// Linux / *BSD 以外では SO_REUSEPORT が無いので、警告を出して通常の bind に
+/// 落ちる。**黙って無効にすると「有効にしたつもりで瞬断する」**ため。
+fn bind_listener(addr: std::net::SocketAddr, reuse_port: bool) -> std::io::Result<TcpListener> {
+    if !reuse_port {
+        return TcpListener::from_std(std::net::TcpListener::bind(addr)?);
+    }
+
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "macos"
+    )))]
+    {
+        warn!(
+            "server.reuse_port is set but SO_REUSEPORT is not available on this platform \
+               — falling back to a plain bind (deploys will still cause a brief drop)"
+        );
+        return TcpListener::from_std(std::net::TcpListener::bind(addr)?);
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "macos"
+    ))]
+    {
+        use socket2::{Domain, Protocol, Socket, Type};
+
+        let socket = Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))?;
+        socket.set_reuse_address(true)?;
+        socket.set_reuse_port(true)?;
+        // tokio に渡す前に non-blocking にしておく（blocking のままだと accept で固まる）
+        socket.set_nonblocking(true)?;
+        socket.bind(&addr.into())?;
+        // backlog: ローリング中は2プロセスで受けるので、片方あたりも余裕を持たせる
+        socket.listen(1024)?;
+        TcpListener::from_std(std::net::TcpListener::from(socket))
+    }
+}
+
 #[tokio::main]
 async fn main() {
     // GW-24: VOLTA_LOG_FORMAT=pretty for human-readable logs (default: json)
@@ -188,11 +248,11 @@ async fn main() {
 
     info!(port = config.server.port, "volta-gateway starting");
 
-    let listener = TcpListener::bind(addr).await.unwrap_or_else(|e| {
+    let listener = bind_listener(addr, config.server.reuse_port).unwrap_or_else(|e| {
         error!("failed to bind {addr}: {e} (port already in use?)");
         std::process::exit(1);
     });
-    info!(addr = %addr, "listening");
+    info!(addr = %addr, reuse_port = config.server.reuse_port, "listening");
 
     // Shared snapshot of config-source (services.json/docker/http) routes so a
     // SIGHUP / admin reload can re-merge them instead of dropping them.


### PR DESCRIPTION
## 何が問題だったか

デプロイは「止める → 差し替える → 起動する」で、その間 `:80` を誰も listen していないため**数秒すべての `*.unlaxer.org` が接続拒否**になっていました。`restart: always` と `drain_timeout_secs` は「落ちたら戻す」「落とすとき in-flight を守る」ための設定で、**切り替えの瞬間に開く穴**は塞げていません。

## 仕組み（案 (a) SO_REUSEPORT を採用）

`server.reuse_port: true` で同じ `:80` に複数プロセスが bind でき、カーネルが新規接続を分散します:

```
1. 新バイナリのプロセスを起動   ← 新旧2つが listen
2. 旧に SIGTERM                 ← drain 開始
3. 旧が in-flight を流し切って終了
```

`SO_REUSEADDR` だけでは足りません（TIME_WAIT の再利用はできるが**同時に listen はできない**）。

案 (b) の「薄いフロント + blue-green」を採らなかったのは、単一ホストで nginx/HAProxy をもう1段挟むと**そのフロント自身が単一障害点になり、更新時に同じ問題が起きる**ためです。

## 既定は false

既存デプロイで勝手に有効になると「**古いプロセスが残っていることに気付かないまま新旧が同時に動く**」事故が起きえます（「再起動したのに古い挙動のまま」の原因が読めなくなる）。手順を整えてから opt-in する形にしました。

Linux / *BSD / macOS 以外では警告を出して通常の bind に落ちます。**黙って無効にすると「有効にしたつもりで瞬断する」**ので、必ずログに残します。

## 実測（2026-08-13）

同一設定の2プロセスを `:18080` に立て、旧に SIGTERM を送りながら 100ms 間隔で 60 回叩きました:

| 応答 | 回数 |
|---|---:|
| 200 | 59 |
| 503 | 1 |
| **接続失敗** | **0** |

**接続拒否ゼロ** = `:80` は瞬断していません。受け入れ条件「バイナリ更新時に :80 への接続が落ちない」を満たします。

503 は drain 中の旧プロセスの `/healthz` に当たったもので、これは設計どおり（「このインスタンスに新規を回すな」を上流に伝える）。実トラフィックは drain 中も処理されます。ただし**外形監視が `/healthz` を叩くとローリング中に一瞬 down と判定されうる**点は docs に書きました（cf-health-worker は2回連続失敗で down 宣言なので誤報にはならない）。drain 開始時に listener を閉じれば 503 も消せますが未実装です。

## docs

`docs/zero-downtime-deploy.md` に手順を書きました。**「新プロセスが listen したことを確認してから旧を落とす」**を強調しています（飛ばすと、新プロセスが設定エラーで起動失敗しているのに旧を落として全滅する）。

## 検証

`cargo test --workspace` → **541 tests pass**（537 + reuse_port の既定/有効化テスト2件ほか）

## 残り

**BT-HA-1（Docker healthcheck で hang したインスタンスを置き換える）は未対応**で `#74` に残します。crash は `restart: always` で戻りますが、無応答は拾えません。
