### PR TITLE
feat(gateway): --health-check を追加して hang を Docker に拾わせる (#74 BT-HA-1)

### DIFF
--- a/docs/zero-downtime-deploy.md
+++ b/docs/zero-downtime-deploy.md
@@ -90,8 +90,60 @@ ssh prod 'ss -ltnp | grep :80'
 気になるなら drain 開始時に listener を閉じる（新規接続をカーネルが残りの
 プロセスへ回す）ようにすれば 503 も出なくなる。**未実装**。
 
-## 残り: BT-HA-1（Docker healthcheck）
+## BT-HA-1: hang したインスタンスを置き換える
 
-`/healthz` を叩く healthcheck を compose に入れて、**hang したインスタンスを
-Docker に置き換えさせる**話は未対応。crash は `restart: always` で戻るが、
-無応答は拾えない。`#74` に残す。
+`restart: always` は**プロセスが死んだとき**しか効かない。**応答しないが生きている
+（hang）状態は拾えない。** 実際 2026-08-06 に gateway が 10時間 502 を返し続けた間、
+コンテナは Running のままだった。
+
+### `--health-check`
+
+```bash
+volta-gateway --health-check 80    # 2xx なら exit 0、それ以外は exit 1
+```
+
+`http://127.0.0.1:<port>/healthz` を叩く。**curl / wget を使わない**のは、本番
+イメージが `debian:bookworm-slim` で**どちらも入っていない**ため。パッケージを
+足すとイメージが変わるので、既にマウントされているバイナリ自身で叩く。
+
+Host ヘッダには routing に載っていない値（`127.0.0.1`）を送る。routing にある
+Host を送ると backend へ proxy されてしまい、**gateway 自身ではなく backend の
+健康を見てしまう**（`dc4b098` で直した挙動そのもの）。
+
+### compose に入れる
+
+```yaml
+services:
+  gateway:
+    # ... 既存の設定 ...
+    healthcheck:
+      test: ["CMD", "./volta-gateway", "--health-check", "80"]
+      interval: 30s
+      timeout: 5s
+      # drain 中は /healthz が 503 を返す。ローリング更新の最中に殺されないよう
+      # retries を積む（30s × 3 = 90s 応答が無ければ unhealthy）。
+      retries: 3
+      start_period: 10s
+```
+
+`restart: always` と組み合わせると、unhealthy になったコンテナを Docker が
+再起動する。
+
+### 適用手順（prod）
+
+```bash
+# 1. 新バイナリを配置（--health-check を含むもの）
+scp target/release/volta-gateway prod:/home/opa/volta-gateway/volta-gateway
+
+# 2. compose に healthcheck を追記
+
+# 3. 反映（この時点では一度落ちる。reuse_port のローリングを使うなら上の手順で）
+ssh prod 'cd /home/opa/volta-gateway && docker compose up -d'
+
+# 4. 効いているか確認
+ssh prod 'docker inspect --format "{{.State.Health.Status}}" volta-gateway'
+```
+
+**3 で一度落ちる**点に注意。compose の設定変更はコンテナの再作成を伴うので、
+無停止でやりたければ先に `reuse_port` のローリング（上記）で新プロセスを立てて
+おくこと。

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -35,6 +35,59 @@ mod websocket;
 use auth::VoltaAuthClient;
 use proxy::{host_is_routed, HotState, ProxyService};
 
+/// `--health-check <port>` の実体 (#74 BT-HA-1)。
+///
+/// `http://127.0.0.1:<port>/healthz` を叩いて、2xx なら 0、それ以外は 1 を返す。
+/// **drain 中は /healthz が 503 を返す**ので、その間 unhealthy と判定される。
+/// これは意図どおり（新規を回してほしくない状態）で、compose 側は `retries` を
+/// 積んでローリング中に殺されないようにする。
+///
+/// tokio ランタイムの外から呼ぶので、std の TcpStream で最小限の HTTP/1.1 を
+/// 手書きする（hyper を持ち込むとランタイムが要る）。
+fn run_health_check(port: u16) -> i32 {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let addr = format!("127.0.0.1:{port}");
+    let mut stream = match TcpStream::connect(&addr) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("health check: connect {addr} failed: {e}");
+            return 1;
+        }
+    };
+    // hang を拾うのが目的なので、必ずタイムアウトを置く
+    let timeout = Duration::from_secs(3);
+    let _ = stream.set_read_timeout(Some(timeout));
+    let _ = stream.set_write_timeout(Some(timeout));
+
+    // Host は routing に載っていないものを使う。routing にある Host を送ると
+    // backend へ proxy されてしまい、**gateway 自身ではなく backend の健康を
+    // 見てしまう**（dc4b098 で直した挙動そのもの）。
+    let req = format!("GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+    if let Err(e) = stream.write_all(req.as_bytes()) {
+        eprintln!("health check: write failed: {e}");
+        return 1;
+    }
+
+    let mut buf = Vec::new();
+    if let Err(e) = stream.take(4096).read_to_end(&mut buf) {
+        eprintln!("health check: read failed: {e}");
+        return 1;
+    }
+    let head = String::from_utf8_lossy(&buf);
+    let status_line = head.lines().next().unwrap_or("");
+    let code = status_line.split_whitespace().nth(1).unwrap_or("");
+
+    if code.starts_with('2') {
+        0
+    } else {
+        eprintln!("health check: unhealthy ({status_line})");
+        1
+    }
+}
+
 /// リスナーを作る。`reuse_port` が真なら SO_REUSEPORT を立てる（#74 BT-HA-2）。
 ///
 /// SO_REUSEPORT を立てると **同じアドレスに複数プロセスが bind できる**。
@@ -118,6 +171,26 @@ async fn main() {
 
     // #36: --validate dry-run mode
     let args: Vec<String> = std::env::args().collect();
+
+    // #74 BT-HA-1: Docker healthcheck 用の自己診断モード。
+    //
+    // compose の healthcheck から呼ぶ。`restart: always` は**プロセスが死んだとき**
+    // しか効かないので、hang（応答しないが生きている）は拾えない。実際に
+    // 2026-08-06 に gateway が 10時間 502 を返し続けたが、コンテナは Running の
+    // ままだった。
+    //
+    // curl / wget を使わないのは、本番イメージが debian:bookworm-slim で
+    // **どちらも入っていない**ため。パッケージを足すとイメージが変わるので、
+    // 既にマウントされているこのバイナリ自身で叩く。
+    if args.iter().any(|a| a == "--health-check") {
+        let port = args
+            .iter()
+            .position(|a| a == "--health-check")
+            .and_then(|i| args.get(i + 1))
+            .and_then(|s| s.parse::<u16>().ok())
+            .unwrap_or(80);
+        std::process::exit(run_health_check(port));
+    }
     let validate_only = args.iter().any(|a| a == "--validate");
     let config_path = args
         .iter()


### PR DESCRIPTION
`#74` の残り（BT-HA-1）。BT-HA-2（SO_REUSEPORT）は PR #110 で入りました。

## 何が拾えていなかったか

`restart: always` は**プロセスが死んだとき**しか効きません。**応答しないが生きている（hang）状態は拾えない。** 実際 2026-08-06 に gateway が 10時間 502 を返し続けた間、**コンテナは Running のまま**でした。

## `--health-check`

```bash
volta-gateway --health-check 80    # 2xx なら exit 0、それ以外は exit 1
```

判断したこと:

- **curl / wget を使わない** — 本番イメージが `debian:bookworm-slim` で**どちらも入っていない**。パッケージを足すとイメージが変わるので、既にマウントされているバイナリ自身で叩く
- **Host は routing に載っていない値（`127.0.0.1`）を送る** — routing にある Host を送ると backend へ proxy され、**gateway 自身ではなく backend の健康を見てしまう**（`dc4b098` で直した挙動そのもの）
- tokio ランタイムの外から呼ぶので std の `TcpStream` で最小限の HTTP/1.1 を手書き。**hang を拾うのが目的なので read/write に必ずタイムアウト**を置く

## 実測

| 状態 | 結果 |
|---|---|
| gateway 未起動 | `exit 1`（connect 失敗） |
| gateway 稼働中 | `exit 0` |

## compose

`docs/zero-downtime-deploy.md` に断片と適用手順を追記しました。

```yaml
healthcheck:
  test: ["CMD", "./volta-gateway", "--health-check", "80"]
  interval: 30s
  timeout: 5s
  retries: 3        # drain 中は /healthz が 503 を返すので積む
  start_period: 10s
```

**注意点を2つ書きました:**
- drain 中は `/healthz` が 503 を返すので、ローリング更新の最中に殺されないよう `retries` を積む
- **compose の変更自体はコンテナ再作成を伴う**ので、無停止でやりたければ先に `reuse_port` のローリングで新プロセスを立てておく

## prod への適用

**この PR には prod の `docker-compose.yml` の変更は含めていません**（repo 外のファイルなので）。手順は docs に書いたので、適用は別途お願いします。

## 検証

`cargo test --workspace` → **541 tests pass**
