### PR TITLE
feat: access.minRole を ForwardAuth で実効化する (#58)

### DIFF
--- a/auth-core/src/policy.rs
+++ b/auth-core/src/policy.rs
@@ -303,4 +303,53 @@ mod tests {
         assert!(!policy.can("MEMBER", "remove_members"));
         assert!(!policy.can("MEMBER", "change_member_role"));
     }
+    // ── #58: ForwardAuth のロール判定で使う階層 ────────────────────
+    //
+    // services.json の `access.minRole` を auth-server が評価するようになった。
+    // ここがずれると「ADMIN 限定のつもりが VIEWER で通る」になるので固定する。
+
+    #[test]
+    fn min_role_allows_equal_or_higher() {
+        let p = PolicyEngine::default_policy();
+        // OWNER > ADMIN > MEMBER > VIEWER
+        assert!(p.is_at_least("OWNER", "ADMIN"));
+        assert!(p.is_at_least("ADMIN", "ADMIN"));
+        assert!(p.is_at_least("ADMIN", "MEMBER"));
+        assert!(p.is_at_least("MEMBER", "VIEWER"));
+    }
+
+    #[test]
+    fn min_role_denies_lower() {
+        let p = PolicyEngine::default_policy();
+        assert!(!p.is_at_least("VIEWER", "MEMBER"));
+        assert!(!p.is_at_least("MEMBER", "ADMIN"));
+        assert!(!p.is_at_least("ADMIN", "OWNER"));
+    }
+
+    #[test]
+    fn enforce_min_role_uses_any_of_the_users_roles() {
+        // ユーザーは複数ロールを持ちうる。どれか1つが足りていれば通す。
+        let p = PolicyEngine::default_policy();
+        let roles = vec!["VIEWER".to_string(), "ADMIN".to_string()];
+        assert!(matches!(
+            p.enforce_min_role(&roles, "ADMIN"),
+            PolicyResult::Allow
+        ));
+        assert!(matches!(
+            p.enforce_min_role(&roles, "OWNER"),
+            PolicyResult::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn unknown_role_is_denied() {
+        // 階層に無いロール（typo や独自ロール）を「通す」と危ない。
+        let p = PolicyEngine::default_policy();
+        assert!(!p.is_at_least("SUPERUSER", "VIEWER"));
+        let roles = vec!["SUPERUSER".to_string()];
+        assert!(matches!(
+            p.enforce_min_role(&roles, "VIEWER"),
+            PolicyResult::Deny(_)
+        ));
+    }
 }

--- a/auth-server/src/handlers/auth.rs
+++ b/auth-server/src/handlers/auth.rs
@@ -133,6 +133,48 @@ pub async fn verify(State(state): State<AppState>, headers: HeaderMap, jar: Cook
             }
         }
 
+        // #58 / volta-platform#41: ルートが要求する最低ロールを満たすか。
+        //
+        // gateway が `X-Volta-Required-Role` で「何が必要か」を渡してくる
+        // （services.json の `access.minRole` 由来）。**判定をこちら側でやるのは、
+        // ロールの正がセッションにあるため。** gateway に判定させると、gateway が
+        // ロール階層を知る必要が出て二重管理になる。
+        //
+        // これまで minRole は services.json に書けるだけで**誰も読んでいなかった**。
+        // 「operator 限定にしたつもり」でも viewer でログインすれば通っていた。
+        //
+        // 403 を返すのは、ログインし直しても足りないロールは満たせないため
+        // （302 で /login に送ると無限ループになる）。
+        if let Some(required) = headers
+            .get("x-volta-required-role")
+            .and_then(|v| v.to_str().ok())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            let policy = volta_auth_core::policy::PolicyEngine::default_policy();
+            let satisfied = session
+                .roles
+                .iter()
+                .any(|r| policy.is_at_least(r, required));
+            if !satisfied {
+                tracing::warn!(
+                    user_id = %session.user_id,
+                    roles = ?session.roles,
+                    required = required,
+                    "verify denied: role requirement not met"
+                );
+                let mut resp = StatusCode::FORBIDDEN.into_response();
+                let h = resp.headers_mut();
+                h.insert("x-volta-auth-reason", "insufficient_role".parse().unwrap());
+                // 何が足りないかを返す。画面側が「ADMIN が必要です」と出せる。
+                if let Ok(v) = required.parse() {
+                    h.insert("x-volta-required-role", v);
+                }
+                no_cache_headers(&mut resp);
+                return resp;
+            }
+        }
+
         // P1.1 AUTH-010: MFA pending → send user to challenge (only if they are
         // not already navigating to the MFA page, to avoid redirect loops).
         // Only enforce when the user actually has an *active* second factor —

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -283,6 +283,8 @@ impl VoltaAuthClient {
         proto: &str,
         cookie: Option<&str>,
         app_id: Option<&str>,
+        // #58: このルートに必要な最低ロール。auth-server が評価する。
+        min_role: Option<&str>,
         client_ip: Option<&str>,
     ) -> AuthResult {
         // DD-005 Phase 0: In-process JWT verify (skip HTTP roundtrip).
@@ -314,6 +316,9 @@ impl VoltaAuthClient {
             cookie.unwrap_or("").hash(&mut h);
             host.hash(&mut h);
             app_id.unwrap_or("").hash(&mut h);
+            // #58: 必要ロールが違えば判定結果も違う。混ぜないと、
+            // 別ルートの許可結果を使い回してしまう
+            min_role.unwrap_or("").hash(&mut h);
             h.finish()
         };
         {
@@ -339,6 +344,12 @@ impl VoltaAuthClient {
         }
         if let Some(id) = app_id {
             builder = builder.header("X-Volta-App-Id", id);
+        }
+        // #58: 必要ロールを渡す。判定は auth-server 側（ロールの正はセッションに
+        // あるため）。gateway は「何が必要か」を伝えるだけで、足りるかどうかは
+        // 見ない。ここで判定すると、gateway がロール階層を知る必要が出て二重管理。
+        if let Some(role) = min_role {
+            builder = builder.header("X-Volta-Required-Role", role);
         }
         if let Some(ip) = client_ip {
             builder = builder.header("X-Real-IP", ip);

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -608,7 +608,9 @@ mod degraded_tests {
     async fn check_valid_session_survives_proxy_down() {
         let c = client(true);
         let cookie = valid_cookie();
-        let r = c.check("h", "/", "https", Some(&cookie), None, None).await;
+        let r = c
+            .check("h", "/", "https", Some(&cookie), None, None, None)
+            .await;
         assert!(
             matches!(r, AuthResult::Authenticated(_)),
             "valid session must survive auth-proxy outage"
@@ -619,7 +621,7 @@ mod degraded_tests {
     async fn check_no_session_proxy_down_fail_closed_when_off() {
         let c = client(false);
         // クッキー無し → Phase 0 は NoSession で fall-through → HTTP 失敗 → degraded off → Error
-        let r = c.check("h", "/", "https", None, None, None).await;
+        let r = c.check("h", "/", "https", None, None, None, None).await;
         assert!(matches!(r, AuthResult::Error(_)));
     }
 
@@ -734,7 +736,9 @@ mod degraded_tests {
         c.degraded_mode = true;
         let cookie = rs256_cookie(Some("volta-auth"), Some("volta-apps"));
         // auth-proxy unreachable → Phase 0 in-process RS256 verify must pass.
-        let r = c.check("h", "/", "https", Some(&cookie), None, None).await;
+        let r = c
+            .check("h", "/", "https", Some(&cookie), None, None, None)
+            .await;
         match r {
             AuthResult::Authenticated(h) => {
                 assert_eq!(h.get("x-volta-user-id").unwrap(), "rs-user");
@@ -760,7 +764,7 @@ mod degraded_tests {
         parts[2] = &bad_sig;
         let tampered = parts.join(".");
         let r = c
-            .check("h", "/", "https", Some(&tampered), None, None)
+            .check("h", "/", "https", Some(&tampered), None, None, None)
             .await;
         assert!(
             matches!(r, AuthResult::Error(_)),
@@ -775,7 +779,9 @@ mod degraded_tests {
         let mut c = VoltaAuthClient::new(&rs256_config());
         c.degraded_mode = true;
         let cookie = rs256_cookie(Some("evil-issuer"), Some("volta-apps"));
-        let r = c.check("h", "/", "https", Some(&cookie), None, None).await;
+        let r = c
+            .check("h", "/", "https", Some(&cookie), None, None, None)
+            .await;
         assert!(
             matches!(r, AuthResult::Error(_)),
             "wrong iss must be rejected"
@@ -809,7 +815,7 @@ mod degraded_tests {
         c.degraded_mode = true;
         // HS256 cookie (signed with SECRET) must still verify via the chain.
         let r = c
-            .check("h", "/", "https", Some(&valid_cookie()), None, None)
+            .check("h", "/", "https", Some(&valid_cookie()), None, None, None)
             .await;
         assert!(
             matches!(r, AuthResult::Authenticated(_)),

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -807,6 +807,7 @@ mod tests {
 
     fn make_route(host: &str, backend: &str) -> RouteEntry {
         RouteEntry {
+            min_role: None,
             host: host.to_string(),
             backend: Some(backend.to_string()),
             backends: vec![],
@@ -831,6 +832,7 @@ mod tests {
 
     fn make_weighted_route(host: &str, backends: Vec<WeightedBackend>) -> RouteEntry {
         RouteEntry {
+            min_role: None,
             host: host.to_string(),
             backend: None,
             backends,
@@ -903,6 +905,7 @@ routing:
     fn all_backends_single_not_duplicated_when_also_in_backends() {
         // backend field url already appears in backends — should not duplicate
         let route = RouteEntry {
+            min_role: None,
             host: "example.com".into(),
             backend: Some("http://a:3000".into()),
             backends: vec![WeightedBackend {
@@ -933,6 +936,7 @@ routing:
     #[test]
     fn all_backends_empty_when_none_configured() {
         let route = RouteEntry {
+            min_role: None,
             host: "example.com".into(),
             backend: None,
             backends: vec![],

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -379,6 +379,20 @@ pub struct RouteEntry {
     pub backends: Vec<WeightedBackend>,
     #[serde(default)]
     pub app_id: Option<String>,
+
+    /// このルートに必要な最低ロール（#58 / volta-platform#41）。
+    ///
+    /// `VIEWER` < `MEMBER` < `ADMIN` < `OWNER`。指定すると ForwardAuth に
+    /// `X-Volta-Required-Role` を渡し、**auth-server がセッションのロールと
+    /// 突き合わせて足りなければ 403** を返す。
+    ///
+    /// これまで services.json に `access.minRole` を書いても**誰も読んでいなかった**
+    /// ため、「operator 限定にしたつもり」でも viewer でログインすれば通っていた。
+    /// 判定を auth-server 側でやるのは、ロールの正はセッション（＝auth-server）に
+    /// あるため。gateway は「何が必要か」を渡すだけにする。
+    #[serde(default)]
+    pub min_role: Option<String>,
+
     #[serde(default)]
     pub ip_allowlist: Vec<String>,
     /// Allowed CORS origins for this route. Empty = no CORS headers.
@@ -737,6 +751,7 @@ impl GatewayConfig {
                         backends: r.all_backends(),
                         weights: r.all_weights(),
                         app_id: r.app_id.clone(),
+                        min_role: r.min_role.clone(),
                         public: r.public,
                         bypass_paths: r.auth_bypass_paths.clone(),
                         mirror: r.mirror.clone(),

--- a/gateway/src/config_source.rs
+++ b/gateway/src/config_source.rs
@@ -275,6 +275,7 @@ impl ServicesJsonSource {
             .collect();
 
         Ok(Some(RouteEntry {
+            min_role: None,
             host,
             backend: Some(backend),
             backends: vec![],
@@ -322,6 +323,7 @@ impl ServicesJsonSource {
                 .collect();
 
             routes.push(RouteEntry {
+                min_role: None,
                 host,
                 backend: Some(backend),
                 backends: vec![],
@@ -468,6 +470,7 @@ impl DockerLabelsSource {
             .unwrap_or_default();
 
         Some(RouteEntry {
+            min_role: None,
             host: host.clone(),
             backend: Some(format!("http://{}:{}", container_ip, port)),
             backends: vec![],
@@ -765,6 +768,7 @@ pub fn spawn_watchers(
                 let mut this_source: crate::proxy::RoutingTable = std::collections::HashMap::new();
                 for route in &dynamic_routes {
                     let info = crate::proxy::RouteInfo {
+                        min_role: route.min_role.clone(),
                         backends: route.all_backends(),
                         weights: route.all_weights(),
                         app_id: route.app_id.clone(),

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -1783,6 +1783,7 @@ mod circuit_breaker_tests {
 
     fn route_stub() -> RouteInfo {
         RouteInfo {
+            min_role: None,
             backends: vec!["http://127.0.0.1:1".into()],
             weights: vec![],
             app_id: None,

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -81,6 +81,8 @@ pub struct RouteInfo {
     /// Weights for weighted routing (same length as backends). Empty = equal weight.
     pub weights: Vec<u32>,
     pub app_id: Option<String>,
+    /// ForwardAuth に渡す最低ロール（#58）。
+    pub min_role: Option<String>,
     pub public: bool,
     pub bypass_paths: Vec<crate::config::BypassPath>,
     pub mirror: Option<crate::config::MirrorConfig>,
@@ -755,7 +757,7 @@ impl ProxyService {
 
         // SM should be in ROUTED state now (waiting for External: auth check)
         // Extract route target from SM context
-        let (backend_url, app_id) = {
+        let (backend_url, app_id, min_role) = {
             let eng = engine.lock().unwrap();
             let flow = match eng.store.get(&flow_id) {
                 Some(f) => f,
@@ -773,7 +775,10 @@ impl ProxyService {
                         .backend_selector
                         .select(&host, &rt.backends, weights)
                         .to_string();
-                    (selected, rt.app_id.clone())
+                    // #58: 必要ロールは routing から引く（RouteTarget は flow の
+                    // context なので、ここで hot state から取る方が単純）
+                    let min_role = route.and_then(|r| r.min_role.clone());
+                    (selected, rt.app_id.clone(), min_role)
                 }
                 Err(_) => return error_response(StatusCode::BAD_REQUEST, &request_id),
             }
@@ -817,6 +822,7 @@ impl ProxyService {
                     proto,
                     cookie.as_deref(),
                     app_id.as_deref(),
+                    min_role.as_deref(),
                     Some(&client_ip_str),
                 )
                 .await;

--- a/gateway/src/websocket.rs
+++ b/gateway/src/websocket.rs
@@ -72,6 +72,7 @@ pub async fn handle_websocket(
     };
     let backends = route.backends;
     let app_id = route.app_id;
+    let min_role = route.min_role;
 
     // Public routes skip auth; bypass_paths also skip for matching prefixes
     let skip_auth = route.public
@@ -103,6 +104,7 @@ pub async fn handle_websocket(
                 "https",
                 cookie.as_deref(),
                 app_id.as_deref(),
+                min_role.as_deref(),
                 Some(&client_ip_str),
             )
             .await;

--- a/gateway/tests/flow_test.rs
+++ b/gateway/tests/flow_test.rs
@@ -14,6 +14,7 @@ fn test_routing() -> Arc<RoutingTable> {
     rt.insert(
         "app.example.com".into(),
         RouteInfo {
+            min_role: None,
             weights: vec![],
             backends: vec!["http://localhost:3000".into()],
             app_id: Some("app-wiki".into()),
@@ -35,6 +36,7 @@ fn test_routing() -> Arc<RoutingTable> {
     rt.insert(
         "*.example.com".into(),
         RouteInfo {
+            min_role: None,
             weights: vec![],
             backends: vec!["http://localhost:3001".into()],
             app_id: None,

--- a/gateway/tests/integration_test.rs
+++ b/gateway/tests/integration_test.rs
@@ -84,6 +84,7 @@ fn make_proxy(auth_addr: SocketAddr, backend_addr: SocketAddr, host: &str) -> Pr
     routing.insert(
         host.to_string(),
         volta_gateway::proxy::RouteInfo {
+            min_role: None,
             weights: vec![],
             backends: vec![format!("http://{}", backend_addr)],
             app_id: Some("test-app".into()),
@@ -135,6 +136,7 @@ fn make_proxy_with_cors(
     routing.insert(
         host.to_string(),
         volta_gateway::proxy::RouteInfo {
+            min_role: None,
             weights: vec![],
             backends: vec![format!("http://{}", backend_addr)],
             app_id: Some("test-app".into()),
@@ -466,6 +468,7 @@ fn make_proxy_public(backend_addr: SocketAddr, host: &str) -> ProxyService {
     routing.insert(
         host.to_string(),
         volta_gateway::proxy::RouteInfo {
+            min_role: None,
             weights: vec![],
             backends: vec![format!("http://{}", backend_addr)],
             app_id: Some("public-app".into()),
@@ -516,6 +519,7 @@ fn make_proxy_with_bypass(
     routing.insert(
         host.to_string(),
         volta_gateway::proxy::RouteInfo {
+            min_role: None,
             weights: vec![],
             backends: vec![format!("http://{}", backend_addr)],
             app_id: Some("bypass-app".into()),


### PR DESCRIPTION
`volta-platform#41` の残り「`access.minRole` が実効していない」の本体です。

## 何が起きていたか

`services.json` に `access.minRole` を書けるのに**誰も読んでいませんでした**。「operator 限定にしたつもり」でも viewer でログインすれば通る状態で、2026-08-14 の実測では minRole を持つ6件すべてが「ログイン必須」までしか効いていませんでした。

## 経路

```
services.json (access.minRole)
  → generate-gateway-routes.py          ← volta-platform aca3424
  → volta-gateway.yaml (routing[].min_role)
  → gateway が X-Volta-Required-Role で送る
  → auth-server がセッションのロールと突き合わせて 403   ← 本体
```

## 判定を auth-server 側でやる理由

**ロールの正はセッション（＝auth-server）にあります。** gateway に判定させると gateway がロール階層を知る必要が出て二重管理になるので、**gateway は「何が必要か」を伝えるだけ**にして、足りるかどうかは見ません。

## 403 を返す理由

ログインし直しても足りないロールは満たせないので、302 で `/login` に送ると無限ループになります。`X-Volta-Auth-Reason: insufficient_role` と `X-Volta-Required-Role` を返すので、画面側が「ADMIN が必要です」と出せます。

## 実装で気をつけた点

- **キャッシュキーに min_role を混ぜました** — 必要ロールが違えば判定結果も違うので、混ぜないと別ルートの許可結果を使い回します
- **HTTP と WebSocket の両方**の ForwardAuth 経路で送ります
- **階層に無いロールは弾きます**（`is_at_least` の既定挙動）。typo や独自ロールを「通す」方に倒すと危ないので

## 実装して初めて分かった問題

階層は **OWNER > ADMIN > MEMBER > VIEWER** ですが、services.json には **`minRole: "operator"` が4件**あります。`OPERATOR` は階層に無いので、**このまま有効化すると ttyd / ttyd-crt / code-server / syslenz に誰も入れなくなります**。

deploy 前に気付けるよう、`validate-services.py` がエラーにするようにしました（volta-platform 側）。「誰も入れない」は「誰でも入れる」と同じくらい困るので警告ではなくエラーです。

**この4件のロール名を直すまでは、routing に min_role を流さない**（`--apply` しない）でください。

## 検証

`cargo test --workspace` → **545 tests pass**（541 + ロール階層のテスト4件: 同等以上は通す / 下位は弾く / 複数ロールはどれか1つ満たせば通る / 未知のロールは弾く）
